### PR TITLE
feat(dashboard): finaliza a tela de Visão Geral conforme protótipo (#113)

### DIFF
--- a/frontend/src/components/layout/app-sidebar.tsx
+++ b/frontend/src/components/layout/app-sidebar.tsx
@@ -2,7 +2,6 @@ import {
   ChartColumnBigIcon,
   CircleQuestionMarkIcon,
   FileText,
-  HomeIcon,
   LayoutDashboard,
   LogOut,
   Plus,
@@ -22,7 +21,7 @@ import { Button } from "../ui/button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { LogoutApi } from "@/api/auth/logout-api";
 import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 
 const items = [
   {
@@ -45,16 +44,12 @@ const items = [
     url: "/settings",
     icon: SettingsIcon,
   },
-  {
-    title: "Voltar ao site",
-    url: "/",
-    icon: HomeIcon,
-  },
 ];
 
 export default function AppSidebar() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   const logoutMutation = useMutation({
     mutationFn: LogoutApi,
@@ -102,15 +97,16 @@ export default function AppSidebar() {
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton
                     asChild
-                    className="py-4 hover:bg-brand-secondary dark:hover:bg-brand-primary "
+                    isActive={pathname === item.url}
+                    className="py-4 data-[active=true]:bg-brand-primary/10 data-[active=true]:font-medium data-[active=true]:text-brand-primary hover:bg-brand-secondary hover:text-white dark:hover:bg-brand-primary"
                   >
-                    <a
-                      href={item.url}
-                      className="flex items-center gap-3  hover:text-white "
+                    <NavLink
+                      to={item.url}
+                      className="flex items-center gap-3"
                     >
                       <item.icon className={"w-5! h-5!"} />
                       <span>{item.title}</span>
-                    </a>
+                    </NavLink>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -119,19 +115,25 @@ export default function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
       <footer className="p-4">
-        <div className="flex flex-col gap-2">
-          <Button className="bg-brand-secondary dark:bg-brand-primary p-6 hover:bg-brand-secondary">
-            {/** Tds os botoes aqui criar o component */} <Plus /> Novo
-            Currículo
+        <div className="flex flex-col gap-1">
+          <Button className="mb-2 bg-brand-secondary p-6 hover:bg-brand-secondary dark:bg-brand-primary">
+            <Plus /> Novo Currículo
           </Button>
-          <div className="flex gap-1 items-center">
-            <CircleQuestionMarkIcon size={16} /> <h1>Ajuda</h1>
-          </div>
-          <div className="flex gap-1 items-center">
-            <Button  onClick={() => logoutMutation.mutate()} className="text-destructive bg-transparent hover:bg-transparent">
-              <LogOut/> Desconectar
-            </Button>
-          </div>
+
+          <button
+            type="button"
+            className="flex items-center justify-start gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <CircleQuestionMarkIcon size={18} /> Ajuda
+          </button>
+
+          <button
+            type="button"
+            onClick={() => logoutMutation.mutate()}
+            className="flex items-center justify-start gap-2 rounded-lg px-3 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10"
+          >
+            <LogOut size={18} /> Sair
+          </button>
         </div>
       </footer>
     </Sidebar>

--- a/frontend/src/components/ui/OptimizationChart.tsx
+++ b/frontend/src/components/ui/OptimizationChart.tsx
@@ -1,5 +1,4 @@
 import { PieChart, Pie, Cell } from "recharts";
-import { Badge } from "././badge";
 
 const data = [
   { name: "Otimizado", value: 75 },
@@ -11,11 +10,6 @@ const COLORS = ["#2e7bff", "#e5e7eb"]; // espelha --color-brand-primary e --colo
 export function OptimizationChart() {
   return (
     <div className="flex flex-col items-center">
-
-      <Badge className="mb-4 bg-brand-primary text-white">
-        MÉDIA GLOBAL
-      </Badge>
-
       <div className="relative w-[180px] h-[180px]">
   <PieChart width={180} height={180}>
     <Pie

--- a/frontend/src/pages/dashboard/general-view/GeneralView.tsx
+++ b/frontend/src/pages/dashboard/general-view/GeneralView.tsx
@@ -5,6 +5,31 @@ import { OptimizationChart } from "../../../components/ui/OptimizationChart";
 import { Link } from "react-router-dom";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import {
+    Bell,
+    CircleCheck,
+    FileText,
+    MapPin,
+    MoreVertical,
+    Sparkles,
+} from "lucide-react";
+
+const resumes = [
+    {
+        id: 1,
+        name: "Curriculo_ProductDesigner_v2.pdf",
+        score: 92,
+        updatedAt: "Atualizado há 2 dias",
+        tags: ["UX", "UI"],
+    },
+    {
+        id: 2,
+        name: "Curriculo_MarketingDigital.pdf",
+        score: 78,
+        updatedAt: "Atualizado há 1 semana",
+        tags: ["MKT"],
+    },
+];
 
 export default function GeneralView() {
     const { data: user } = useQuery({
@@ -31,16 +56,26 @@ export default function GeneralView() {
                     </p>
                 </div>
 
-                <div className="flex items-center gap-3 rounded-full border border-brand-primary/20 bg-brand-primary/5 px-3 py-1.5">
-                    <Avatar className="size-8">
-                        <AvatarFallback className="size-full bg-brand-primary text-white text-xs font-semibold">
-                            {user?.name?.[0]}
-                        </AvatarFallback>
-                    </Avatar>
+                <div className="flex items-center gap-4">
+                    <button
+                        type="button"
+                        aria-label="Notificações"
+                        className="text-brand-secondary transition-colors hover:text-brand-primary"
+                    >
+                        <Bell className="size-6" />
+                    </button>
 
-                    <span className="text-sm font-medium">
-                        {user?.name}
-                    </span>
+                    <div className="flex items-center gap-3 rounded-full border border-brand-primary/20 bg-brand-primary/5 px-3 py-1.5">
+                        <Avatar className="size-8">
+                            <AvatarFallback className="size-full bg-brand-primary text-white text-xs font-semibold">
+                                {user?.name?.[0]}
+                            </AvatarFallback>
+                        </Avatar>
+
+                        <span className="text-sm font-medium">
+                            {user?.name}
+                        </span>
+                    </div>
                 </div>
             </div>
 
@@ -56,10 +91,15 @@ export default function GeneralView() {
                             <OptimizationChart />
                         </div>
                         <div className="flex flex-col flex-1">
-                            <p className="text-sm text-muted-foreground">
-                                Melhor que 92% dos candidatos
-                            </p>
-                            <h2 className="text-3xl font-bold mt-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <Badge className="border-transparent bg-brand-primary text-white">
+                                    MÉDIA GLOBAL
+                                </Badge>
+                                <p className="text-sm text-muted-foreground">
+                                    Melhor que 92% dos candidatos
+                                </p>
+                            </div>
+                            <h2 className="text-3xl font-bold mt-2">
                                 Performance Geral
                             </h2>
                             <p className="mt-4 text-muted-foreground leading-7">
@@ -69,12 +109,12 @@ export default function GeneralView() {
                             </p>
 
                             <div className="flex gap-2 mt-6">
-                                <Badge variant="outline">
-                                    Keywords
-                                </Badge>
-                                <Badge variant="outline">
-                                    Formatação
-                                </Badge>
+                                <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-primary/15 px-3 py-1 text-sm font-medium text-brand-primary">
+                                    <CircleCheck className="size-4" /> Keywords
+                                </span>
+                                <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-primary/15 px-3 py-1 text-sm font-medium text-brand-primary">
+                                    <CircleCheck className="size-4" /> Formatação
+                                </span>
                             </div>
                         </div>
                     </div>
@@ -84,21 +124,21 @@ export default function GeneralView() {
                 {/* IA */}
 
                 <div className="rounded-2xl border border-l-4 border-brand-primary bg-brand-primary/5 p-6">
-                    <div className="flex items-center gap-3 mb-6">
-                        ⭐
+                    <div className="flex items-center gap-2 mb-6">
+                        <Sparkles className="size-5 text-brand-primary" />
                         <h3 className="font-bold text-lg">
                             Dicas da IA
                         </h3>
                     </div>
                     <div className="space-y-5">
                         <div className="flex gap-3">
-                            <div className="w-2 h-2 rounded-full bg-brand-primary mt-2" />
+                            <MapPin className="size-4 shrink-0 text-brand-primary mt-0.5" />
                             <p className="text-sm text-muted-foreground">
                                 Inclua métricas quantitativas na seção de experiências para aumentar o score em até 15%.
                             </p>
                         </div>
                         <div className="flex gap-3">
-                            <div className="w-2 h-2 rounded-full bg-brand-primary mt-2" />
+                            <MapPin className="size-4 shrink-0 text-brand-primary mt-0.5" />
                             <p className="text-sm text-muted-foreground">
                                 A skill "Agile Methodology" é recorrente nas vagas que você analisou.
                             </p>
@@ -110,29 +150,74 @@ export default function GeneralView() {
                 </div>
             </section>
 
-            {/* TÍTULO */}
-
-            <div className="flex justify-between items-center mt-10 mb-4">
-                <h2 className="text-3xl font-bold">
-                    Meus Currículos
-                </h2>
-                <Link
-                    to="/my-resume"
-                    className="text-brand-primary text-sm font-medium hover:underline"
-                >
-                    Ver todos
-                </Link>
-            </div>
-
             {/* SEGUNDA LINHA */}
 
-            <section className="grid grid-cols-[1fr_1fr_340px] gap-6">
-                <div className="rounded-2xl border border-border bg-card p-6 min-h-[290px]">
-                    teste1
+            <section className="grid grid-cols-[1fr_340px] gap-6 mt-10 items-start">
+                <div>
+                    {/* TÍTULO */}
+                    <div className="flex justify-between items-center mb-4">
+                        <h2 className="text-3xl font-bold">
+                            Meus Currículos
+                        </h2>
+                        <Link
+                            to="/my-resume"
+                            className="text-brand-primary text-sm font-medium hover:underline"
+                        >
+                            Ver todos
+                        </Link>
+                    </div>
+
+                    {/* CARDS */}
+                    <div className="grid grid-cols-2 gap-6">
+                        {resumes.map((resume) => (
+                            <div
+                                key={resume.id}
+                                className="flex flex-col justify-between rounded-2xl border border-border bg-card p-6 min-h-[290px]"
+                            >
+                                <div className="flex items-start justify-between">
+                                    <div className="flex size-12 items-center justify-center rounded-lg bg-brand-primary/10">
+                                        <FileText className="size-6 text-brand-primary" />
+                                    </div>
+                                    <div className="text-right">
+                                        <span className="block text-2xl font-bold">
+                                            {resume.score}
+                                        </span>
+                                        <span className="text-xs font-medium text-muted-foreground">
+                                            ATS SCORE
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="mt-4">
+                                    <h3 className="font-semibold break-all">
+                                        {resume.name}
+                                    </h3>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        {resume.updatedAt}
+                                    </p>
+                                </div>
+
+                                <div className="mt-4 flex items-center justify-between">
+                                    <div className="flex gap-2">
+                                        {resume.tags.map((tag) => (
+                                            <Badge key={tag} variant="secondary">
+                                                {tag}
+                                            </Badge>
+                                        ))}
+                                    </div>
+                                    <button
+                                        type="button"
+                                        aria-label="Mais opções"
+                                        className="text-muted-foreground hover:text-foreground"
+                                    >
+                                        <MoreVertical className="size-5" />
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
                 </div>
-                <div className="rounded-2xl border border-border bg-card p-6 min-h-[290px]">
-                    teste2
-                </div>
+
                 <ApplicationProgress />
             </section>
         </div>


### PR DESCRIPTION
## Finaliza a tela de Visão Geral (dashboard)

**Você usou IA para vibe-codar?**
Usei IA como auxílio na implementação da UI, mas revisei todo o código gerado antes de submeter — não foi vibe coding sem revisão.
**Você usou IA como fonte de pesquisa?**
Não.
**Você REVISOU seu código antes de pedir por uma review?**
Sim.
**Você testou localmente?**
Sim — `tsc` (typecheck) e `eslint` passando, e a tela conferida no navegador.

### O que foi feito:
- Adiciona os cards de **"Meus Currículos"** (substituindo os placeholders `teste1`/`teste2`)
- Adiciona o **ícone de notificações** no cabeçalho
- Destaca o **item ativo** na navegação da sidebar (via `NavLink`, sem reload) e remove o item "Voltar ao site"
- Ajusta o card de **Performance**: badge "Média Global" agora inline (antes ficava sobre o gráfico) e chips "Keywords"/"Formatação" com ícone
- Troca o emoji das **"Dicas da IA"** por ícones (`Sparkles` + `MapPin`)

Closes #113
