### PR TITLE
feat(auth): adiciona tela de recuperação de senha

### DIFF
--- a/frontend/src/api/auth/forgot-password-api.ts
+++ b/frontend/src/api/auth/forgot-password-api.ts
@@ -1,0 +1,19 @@
+import { APICONNECTBACKEND } from "@/helpers/api-connect";
+import type { ForgotPasswordType } from "@/types/forgot-password-type";
+
+export async function ForgotPasswordApi(data: ForgotPasswordType) {
+  const response = await fetch(`${APICONNECTBACKEND}/auth/forgot-password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error("Não foi possível enviar o link de recuperação, tente novamente");
+  }
+
+  return response.json();
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+
+const FOOTER_LINKS = [
+  { label: "Sobre", href: "/#sobre" },
+  { label: "Termos de Uso", href: "/termo" },
+  { label: "Privacidade", href: "/termos" },
+  { label: "Contato", href: "/#contato" },
+];
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="bg-brand-secondary text-white">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-8 md:flex-row">
+        <Link to="/" className="flex items-center gap-2">
+          <img src="/logo.png" alt="BomCurrículo" className="h-9 w-auto" />
+
+          <span className="text-lg font-bold">
+            Bom<span className="text-brand-primary">Currículo</span>
+          </span>
+        </Link>
+
+        <nav>
+          <ul className="flex flex-wrap items-center justify-center gap-6">
+            {FOOTER_LINKS.map((link) => (
+              <li key={link.label}>
+                <Link
+                  to={link.href}
+                  className="text-sm text-white/60 hover:text-white"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <p className="text-sm text-white/50">
+          © {year} BomCurrículo. ATS Inteligente. Resultados Reais.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+
+export function Header() {
+  return (
+    <header className="border-b border-border bg-background px-6 py-3">
+      <div className="mx-auto flex max-w-7xl items-center justify-between">
+        <Link to="/" className="flex items-center gap-2">
+          <img src="/logo-dark.png" alt="BomCurrículo" className="h-9 w-auto dark:hidden" />
+          <img src="/logo.png" alt="BomCurrículo" className="hidden h-9 w-auto dark:block" />
+
+          <span className="text-lg font-bold text-foreground">
+            Bom<span className="text-brand-primary">Currículo</span>
+          </span>
+        </Link>
+
+        <div className="flex items-center gap-6">
+          <Link
+            to="/#ajuda"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Ajuda
+          </Link>
+
+          <Link
+            to="/login"
+            className="rounded-lg bg-brand-secondary px-4 py-2 text-sm font-medium text-white hover:bg-brand-secondary/90"
+          >
+            Entrar
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/pages/auth/forgot-password.tsx
+++ b/frontend/src/pages/auth/forgot-password.tsx
@@ -1,0 +1,132 @@
+import {
+  forgotPasswordSchema,
+  type ForgotPasswordFormData,
+} from "@/schemas/auth/forgot-password-schema";
+import { Link } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { ForgotPasswordApi } from "@/api/auth/forgot-password-api";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Footer } from "@/components/layout/Footer";
+import { Header } from "@/components/layout/Header";
+import { ArrowLeft, KeyRound, Mail } from "lucide-react";
+
+export function ForgotPassword() {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitSuccessful },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(forgotPasswordSchema),
+  });
+
+  const mutation = useMutation({
+    mutationFn: ForgotPasswordApi,
+
+    onSuccess: () => {
+      toast.success("Enviamos um link de recuperação para o seu e-mail!");
+    },
+
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  function handleForgotPassword(data: ForgotPasswordFormData) {
+    mutation.mutate(data);
+  }
+
+  const sent = isSubmitSuccessful && mutation.isSuccess;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+
+      <section className="flex flex-1 items-center justify-center bg-background p-4">
+        <div className="w-full max-w-[440px] rounded-xl border border-border bg-card p-8 shadow-2xl sm:p-10">
+          <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-brand-secondary/10">
+            <KeyRound className="h-8 w-8 text-brand-secondary" />
+          </div>
+
+          <h1 className="mb-2 text-2xl font-bold text-foreground lg:text-3xl">
+            Esqueci minha senha
+          </h1>
+
+          <p className="mb-8 text-sm text-muted-foreground lg:text-base">
+            Digite seu e-mail cadastrado e enviaremos um link para você
+            redefinir sua senha.
+          </p>
+
+          {sent ? (
+            <div className="space-y-6">
+              <p className="rounded-lg bg-brand-secondary/10 p-4 text-sm text-foreground">
+                Verifique sua caixa de entrada. Se o e-mail informado estiver
+                cadastrado, você receberá as instruções de recuperação em
+                instantes.
+              </p>
+
+              <Link
+                to="/login"
+                className="flex items-center justify-center gap-2 text-sm font-medium text-brand-secondary hover:underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Voltar para o login
+              </Link>
+            </div>
+          ) : (
+            <form
+              onSubmit={handleSubmit(handleForgotPassword)}
+              className="space-y-6"
+            >
+              <div>
+                <label className="mb-2 block font-medium text-foreground">
+                  Endereço de e-mail
+                </label>
+
+                <div className="relative">
+                  <Mail className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+
+                  <Input
+                    type="email"
+                    className="h-12 rounded-lg border-input-border-strong pl-10 text-foreground lg:h-14"
+                    placeholder="seu@email.com.br"
+                    {...register("email")}
+                  />
+                </div>
+
+                {errors.email && (
+                  <p className="mt-1 text-sm text-destructive">
+                    {errors.email.message}
+                  </p>
+                )}
+              </div>
+
+              <Button
+                type="submit"
+                disabled={mutation.isPending}
+                className="h-12 w-full gap-2 rounded-lg bg-brand-secondary text-base text-white hover:bg-brand-secondary/90 lg:h-14 lg:text-lg"
+              >
+                {mutation.isPending
+                  ? "Enviando..."
+                  : "Enviar link de recuperação"}
+              </Button>
+
+              <Link
+                to="/login"
+                className="flex items-center justify-center gap-2 text-sm font-medium text-brand-secondary hover:underline"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Voltar para o login
+              </Link>
+            </form>
+          )}
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -117,9 +117,18 @@ export function Login() {
               </div>
 
               <div>
-                <label className="mb-2 block font-medium text-foreground">
-                  Senha
-                </label>
+                <div className="mb-2 flex items-center justify-between">
+                  <label className="block font-medium text-foreground">
+                    Senha
+                  </label>
+
+                  <Link
+                    to="/forgot-password"
+                    className="text-sm text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    Esqueceu sua senha?
+                  </Link>
+                </div>
 
                 <Input
                   type="password"

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from "react-router-dom";
 import Home from "../pages/home/Home";
 import { Login } from "@/pages/auth/login";
 import Register from "@/pages/auth/register";
+import { ForgotPassword } from "@/pages/auth/forgot-password";
 import Dashboard from "@/pages/dashboard/Dashboard";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { ProtectedRoute } from "@/components/protectRouter";
@@ -13,6 +14,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/forgot-password" element={<ForgotPassword />} />
 
       <Route element={<ProtectedRoute />}>
         <Route path="/" element={<Home />} />

--- a/frontend/src/schemas/auth/forgot-password-schema.ts
+++ b/frontend/src/schemas/auth/forgot-password-schema.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const forgotPasswordSchema = z.object({
+  email: z.email("Email inválido"),
+});
+export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;

--- a/frontend/src/types/forgot-password-type.ts
+++ b/frontend/src/types/forgot-password-type.ts
@@ -1,0 +1,3 @@
+export type ForgotPasswordType = {
+  email: string;
+};


### PR DESCRIPTION
## Tela de recuperação de senha

**Have you used AI to vibe code?**
Sim, usei o Claude Code para gerar o componente inicial a partir do protótipo em SVG, revisando e ajustando o resultado manualmente (layout, integração com a rota da API e conteúdo do header/footer).

**Have you used AI as a research source?**
Não.

**Have REVIEWED your code before request a review?**
Sim.

**Have you tested locally?**
Sim, validado o typecheck (`tsc --noEmit`) e a navegação entre as rotas `/login` e `/forgot-password`.

### Fixes:
- Adiciona a tela "Esqueci minha senha" (`/forgot-password`), fiel ao protótipo em SVG.
- Integra o formulário com a rota `POST /auth/forgot-password` já existente no backend.
- Adiciona componentes públicos de `Header` e `Footer`, reutilizados na nova tela.
- Adiciona o link "Esqueceu sua senha?" na tela de login apontando para a nova rota.

Closes #119