### PR TITLE
feat(dashboard): cria tela de Meus Currículos conforme protótipo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from "./providers/theme-provider";
 import { AppRoutes } from "./routes/AppRoutes";
+import { Toaster } from "./components/ui/sonner";
 
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
       storageKey="vite-ui-theme"
     >
         <AppRoutes />
+        <Toaster position="top-right" richColors />
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/Home/DeleteResumeDialog.tsx
+++ b/frontend/src/components/Home/DeleteResumeDialog.tsx
@@ -1,0 +1,58 @@
+import { TriangleAlert } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DeleteResumeDialogProps {
+  open: boolean;
+  fileName?: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export default function DeleteResumeDialog({
+  open,
+  fileName,
+  onOpenChange,
+  onConfirm,
+}: DeleteResumeDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div
+            aria-hidden="true"
+            className="flex size-11 shrink-0 items-center justify-center rounded-full bg-destructive/10"
+          >
+            <TriangleAlert className="size-5 text-destructive" />
+          </div>
+          <AlertDialogTitle>Excluir currículo</AlertDialogTitle>
+          <AlertDialogDescription>
+            Tem certeza que deseja excluir{" "}
+            {fileName ? <span className="font-medium text-foreground">{fileName}</span> : "este currículo"}? Essa
+            ação não poderá ser desfeita.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={cn(buttonVariants({ variant: "destructive" }), "bg-destructive text-white hover:bg-destructive/90")}
+          >
+            Excluir currículo
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/Home/ResumeList.tsx
+++ b/frontend/src/components/Home/ResumeList.tsx
@@ -4,13 +4,14 @@ import AddResumeCard from "@/components/Home/AddResumeCard";
 interface ResumeListProps {
   resumes: (ResumeCardProps & { id: string })[];
   limit: number;
+  onDeleteResume?: (id: string) => void;
 }
 
-export default function ResumeList({ resumes, limit }: ResumeListProps) {
+export default function ResumeList({ resumes, limit, onDeleteResume }: ResumeListProps) {
   return (
     <section aria-label="Lista de currículos" className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
       {resumes.map(({ id, ...card }) => (
-        <ResumeCard key={id} {...card} />
+        <ResumeCard key={id} {...card} onDelete={() => onDeleteResume?.(id)} />
       ))}
       <AddResumeCard isLimitReached={resumes.length >= limit} limit={limit} />
     </section>

--- a/frontend/src/components/Home/ResumesHeader.tsx
+++ b/frontend/src/components/Home/ResumesHeader.tsx
@@ -1,7 +1,16 @@
 import { List, Plus, ListFilter } from "lucide-react";
 import { Button } from "../ui/button";
 
-export default function ResumesHeader() {
+interface ResumesHeaderProps {
+  count?: number;
+  limit?: number;
+  onFilter?: () => void;
+  onAdd?: () => void;
+}
+
+export default function ResumesHeader({ count = 2, limit = 5, onFilter, onAdd }: ResumesHeaderProps) {
+  const isLimitReached = count >= limit;
+
   return (
     <header className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
       <div>
@@ -15,14 +24,25 @@ export default function ResumesHeader() {
             className="flex h-9 min-w-0 flex-1 items-center justify-center gap-2 rounded-lg bg-brand-primary-tint px-2.5 text-sm font-medium whitespace-nowrap text-brand-secondary md:flex-none md:px-4 lg:h-11"
           >
             <List className="size-4 shrink-0" />
-            <span className="truncate">2/5 Currículos</span>
+            <span className="truncate">
+              {count}/{limit} Currículos
+            </span>
           </div>
-          <Button className="h-9 lg:h-11 min-w-0 flex-1 gap-2 md:px-4 bg-brand-primary-tint text-brand-secondary hover:bg-brand-primary-tint/90 md:flex-none">
+          <Button
+            onClick={onFilter}
+            className="h-9 lg:h-11 min-w-0 flex-1 gap-2 md:px-4 bg-brand-primary-tint text-brand-secondary hover:bg-brand-primary-tint/90 md:flex-none"
+          >
             <ListFilter className="size-4 shrink-0" />
             <span className="truncate">Filtrar</span>
           </Button>
         </div>
-        <Button className="w-full h-9 lg:h-11 gap-2 md:px-4 bg-brand-primary text-white hover:bg-brand-primary/90 md:w-auto">
+        <Button
+          type="button"
+          onClick={onAdd}
+          disabled={isLimitReached}
+          title={isLimitReached ? "Limite de currículos atingido" : undefined}
+          className="w-full h-9 lg:h-11 gap-2 md:px-4 bg-brand-primary text-white hover:bg-brand-primary/90 md:w-auto disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-primary"
+        >
           <Plus className="size-4" />
           <span className="truncate">Adicionar Currículo</span>
         </Button>

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,148 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border border-border bg-popover bg-clip-padding p-6 text-popover-foreground shadow-lg duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col items-center gap-3 text-center sm:items-start sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-bold text-brand-secondary", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      data-slot="alert-dialog-action"
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      data-slot="alert-dialog-cancel"
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/src/pages/dashboard/my-resume/MyResume.tsx
+++ b/frontend/src/pages/dashboard/my-resume/MyResume.tsx
@@ -30,7 +30,7 @@ export default function MyResume() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <ResumesHeader />
+      <ResumesHeader count={resumes.length} limit={RESUME_LIMIT} />
 
       {isLoading ? (
         <ResumeListSkeleton />

--- a/frontend/src/pages/dashboard/my-resume/MyResume.tsx
+++ b/frontend/src/pages/dashboard/my-resume/MyResume.tsx
@@ -1,13 +1,19 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
 import ResumesHeader from "@/components/Home/ResumesHeader";
 import ResumeList from "@/components/Home/ResumeList";
 import ResumeListSkeleton from "@/components/Home/ResumeListSkeleton";
 import HomeEmptyState from "@/components/Home/HomeEmptyState";
 import AISuggestion from "@/components/Home/AISuggestion";
+import DeleteResumeDialog from "@/components/Home/DeleteResumeDialog";
 import { type ResumeCardProps } from "@/components/Home/ResumeCard";
 
 const RESUME_LIMIT = 5;
 
-const resumes: (ResumeCardProps & { id: string })[] = [
+type Resume = ResumeCardProps & { id: string };
+
+const initialResumes: Resume[] = [
   {
     id: "1",
     fileName: "Curriculo_Engenheiro_Senior.pdf",
@@ -26,7 +32,23 @@ const resumes: (ResumeCardProps & { id: string })[] = [
 
 export default function MyResume() {
   const isLoading = false;
+  const [resumes, setResumes] = useState<Resume[]>(initialResumes);
+  const [resumeToDelete, setResumeToDelete] = useState<Resume | null>(null);
+
   const hasResumes = resumes.length > 0;
+
+  function handleRequestDelete(id: string) {
+    const resume = resumes.find((item) => item.id === id) ?? null;
+    setResumeToDelete(resume);
+  }
+
+  function handleConfirmDelete() {
+    if (!resumeToDelete) return;
+
+    setResumes((prev) => prev.filter((resume) => resume.id !== resumeToDelete.id));
+    toast.success("Currículo excluído com sucesso.");
+    setResumeToDelete(null);
+  }
 
   return (
     <div className="flex flex-1 flex-col">
@@ -36,7 +58,7 @@ export default function MyResume() {
         <ResumeListSkeleton />
       ) : hasResumes ? (
         <>
-          <ResumeList resumes={resumes} limit={RESUME_LIMIT} />
+          <ResumeList resumes={resumes} limit={RESUME_LIMIT} onDeleteResume={handleRequestDelete} />
           <AISuggestion />
         </>
       ) : (
@@ -44,6 +66,13 @@ export default function MyResume() {
           <HomeEmptyState />
         </div>
       )}
+
+      <DeleteResumeDialog
+        open={resumeToDelete !== null}
+        fileName={resumeToDelete?.fileName}
+        onOpenChange={(open) => !open && setResumeToDelete(null)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/dashboard/my-resume/MyResume.tsx
+++ b/frontend/src/pages/dashboard/my-resume/MyResume.tsx
@@ -1,5 +1,49 @@
+import ResumesHeader from "@/components/Home/ResumesHeader";
+import ResumeList from "@/components/Home/ResumeList";
+import ResumeListSkeleton from "@/components/Home/ResumeListSkeleton";
+import HomeEmptyState from "@/components/Home/HomeEmptyState";
+import AISuggestion from "@/components/Home/AISuggestion";
+import { type ResumeCardProps } from "@/components/Home/ResumeCard";
+
+const RESUME_LIMIT = 5;
+
+const resumes: (ResumeCardProps & { id: string })[] = [
+  {
+    id: "1",
+    fileName: "Curriculo_Engenheiro_Senior.pdf",
+    matchPercentage: 85,
+    updatedLabel: "há 2 dias",
+    tags: ["React", "Node.js", "AWS", "TypeScript", "Docker", "GraphQL"],
+  },
+  {
+    id: "2",
+    fileName: "Curriculo_Product_Designer.pdf",
+    matchPercentage: 72,
+    updatedLabel: "há 5 dias",
+    tags: ["Figma", "UX Research"],
+  },
+];
+
 export default function MyResume() {
+  const isLoading = false;
+  const hasResumes = resumes.length > 0;
+
   return (
-    <div>...My Resume</div>
-  )
+    <div className="flex flex-1 flex-col">
+      <ResumesHeader />
+
+      {isLoading ? (
+        <ResumeListSkeleton />
+      ) : hasResumes ? (
+        <>
+          <ResumeList resumes={resumes} limit={RESUME_LIMIT} />
+          <AISuggestion />
+        </>
+      ) : (
+        <div className="flex flex-1 items-center justify-center">
+          <HomeEmptyState />
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Tela de Meus Currículos

**Você usou IA para vibe-codar?**
Sim, usei o Claude Code para gerar a tela reaproveitando os componentes já existentes usados na Home, revisando o resultado antes de submeter.

**Você usou IA como fonte de pesquisa?**
Não.

**Você REVISOU seu código antes de pedir por uma review?**
Sim.

**Você testou localmente?**
Sim, rodei `npm run dev` localmente e conferi visualmente o cabeçalho, o grid de cards, o card de limite atingido, o estado vazio e o fluxo de exclusão (diálogo de confirmação + toast), além de validar o typecheck (`tsc -b`) e o build (`npm run build`).

### O que foi feito:
Implementa a tela de **Meus Currículos** (`/my-resume`, já linkada em "Meus Curriculos" na sidebar), que até então era apenas um placeholder:

- Cabeçalho com título, contador de currículos, filtro e botão "Adicionar Currículo" (`ResumesHeader`)
- Grid de cards de currículo com nome, % de match, data de atualização, tags e ações de baixar/match/excluir (`ResumeList`/`ResumeCard`)
- Card de "Criar Novo Currículo" / aviso de limite atingido (`AddResumeCard`)
- Estado vazio (`HomeEmptyState`) e de carregamento (`ResumeListSkeleton`)
- Card de "Dica da IA" para o currículo (`AISuggestion`)
- **Exclusão de currículo com confirmação:** ao clicar em "Excluir" no card, abre um diálogo de confirmação (`AlertDialog`, Radix UI) antes de remover o currículo, evitando exclusão acidental. Ao confirmar, o item some da lista e o usuário recebe feedback via toast (Sonner), que passou a ser montado na raiz da aplicação (`App.tsx`)

Todos os componentes já existiam prontos (usados na Home) — a tela só faltava ser conectada a eles. Dados dos currículos seguem mockados por enquanto, sem integração com endpoint de currículo no backend — inclusive a exclusão remove o item apenas da lista local; a chamada real de DELETE ficará para quando a listagem for integrada com a API.

Closes #122
