### PR TITLE
chore(ci): ignora bump de typescript incompatível com typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(frontend)"
+    ignore:
+      # typescript-eslint@8.x exige typescript <6.1.0; liberar quando o
+      # peer dependency for atualizado, evitando ERESOLVE no npm ci.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Backend - assets/vite (npm)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## chore(ci): ignora bump de typescript incompatível com typescript-eslint

**Você usou IA para vibe-codar?**
Sim, utilizei e revisei.

**Você usou IA como fonte de pesquisa?**
Sim, consultei o registro do npm para conferir as versões disponíveis do `typescript` e do `typescript-eslint` e seus peer dependencies.

**Você REVISOU seu código antes de pedir por uma review?**
Sim.

**Você testou localmente?**
Não se aplica (mudança de configuração do Dependabot, não há código para rodar).

### O que foi feito:

Parte da #109 (Arrumar CI). O PR #104 do Dependabot tentou atualizar o `typescript` do frontend de `~6.0.2` para `~7.0.2`, mas o `typescript-eslint@^8.x` (até a versão mais recente, 8.64.1) exige `typescript <6.1.0`, quebrando o `npm ci` com `ERESOLVE`.

Não existe uma versão `6.1.x` do typescript — o pacote pulou direto de `6.0.3` para `7.0.2` — então não há atualização segura possível agora. Adiciona uma regra `ignore` no `dependabot.yml` para bloquear bumps de major/minor do `typescript` no frontend até o `typescript-eslint` suportar TS 7 (bumps de patch continuam liberados).
