### PR TITLE
fix(tests): adiciona helpers de teste e builda assets no CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -52,6 +52,19 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend assets
+        run: npm run build
+
       - name: Generate app key
         run: php artisan key:generate
 

--- a/backend/tests/Pest.php
+++ b/backend/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -16,7 +17,7 @@ use Tests\TestCase;
 
 pest()->extend(TestCase::class)
     ->use(RefreshDatabase::class)
-    ->in('Feature');
+    ->in('Feature', 'Unit');
 
 /*
 |--------------------------------------------------------------------------
@@ -44,7 +45,37 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+/**
+ * Cria um usuário (App\Models\User) para testes que só precisam do model,
+ * sem autenticação via API (ex.: testes de trait/serviço que operam
+ * diretamente sobre um usuário já existente). Aceita overrides de atributos,
+ * repassados direto pra factory (ex.: authUser(['password' => bcrypt('x')])).
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function authUser(array $attributes = []): User
 {
-    // ..
+    return User::factory()->create($attributes);
+}
+
+/**
+ * Cria um usuário e autentica via Sanctum, devolvendo o usuário e os
+ * headers prontos para requests às rotas protegidas por auth:sanctum
+ * (grupo /api/client/*). Aceita os mesmos overrides de atributos que authUser().
+ *
+ * @param  array<string, mixed>  $attributes
+ * @return array{user: User, headers: array<string, string>}
+ */
+function actingAsUser(array $attributes = []): array
+{
+    $user = authUser($attributes);
+
+    $token = $user->createToken('test-token')->plainTextToken;
+
+    return [
+        'user' => $user,
+        'headers' => [
+            'Authorization' => 'Bearer '.$token,
+        ],
+    ];
 }


### PR DESCRIPTION
## fix(tests): adiciona helpers de teste, sobe app nos testes Unit e builda assets no CI

**Você usou IA para vibe-codar?**
Sim, utilizei e revisei.

**Você usou IA como fonte de pesquisa?**
Não.

**Você REVISOU seu código antes de pedir por uma review?**
Sim.

**Você testou localmente?**
Sim, via container Docker (não tenho PHP/Node instalados). Rodei `php artisan test` completo antes e depois de cada mudança:
- Antes: 26-28 falhas (dependendo da branch base), muitas por `Call to undefined function authUser()/actingAsUser()`.
- Depois: **28 passando, 11 falhando** — as 11 restantes são falhas conhecidas e documentadas na #109 (testes do Breeze desatualizados, rota `validate-resume` inexistente, e o `ProfileTest` que só fecha quando o PR #128 for mergeado).
- Also revisei o `authUser()`/`actingAsUser()` manualmente: a primeira versão que escrevi não aceitava argumentos, mas `LoginTest` e `ResumeProcessingPublisherTest` chamam `authUser([...])` passando atributos — corrigido pra aceitar overrides antes de abrir o PR.

### O que foi feito:

Parte da #109 (Arrumar CI). Três mudanças para destravar o job "Tests (PHP 8.4)":

1. **`tests/Pest.php`**: adiciona os helpers `authUser(array $attributes = [])` e `actingAsUser(array $attributes = [])`, usados por vários testes mas nunca implementados (só existia uma função placeholder `something()`, removida). `authUser()` cria um `App\Models\User`; `actingAsUser()` cria o usuário e devolve headers com token Sanctum, pra requests em rotas `auth:sanctum`.
2. **`tests/Pest.php`**: `pest()->extend(TestCase::class)->in('Feature', 'Unit')` — antes só cobria `Feature`, então os testes em `tests/Unit/*` (que usam facades como `Storage::fake()` e o helper `authUser()`) nunca subiam o app Laravel.
3. **`.github/workflows/backend-ci.yml`**: adiciona `npm ci` + `npm run build` no job de testes, antes de `php artisan test`. Sem isso, qualquer teste que renderiza uma view Blade com `@vite(...)` (login, profile) quebra com "Vite manifest not found".

Sem mudança de lógica de produção — só infraestrutura de teste e CI.
