### PR TITLE
docs: adiciona seção 'antes de abrir um PR' e novo colaborador

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,15 @@ Description of what you have fixed. You can also upload screenshots if needed.
 
 ```
 
+## Before opening a PR
+
+- **Backend (PHP):** run `vendor/bin/pint` before committing — it auto-fixes code style. If you don't have PHP installed, run it via Docker:
+  `docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli vendor/bin/pint`
+- **Mobile (Flutter):** run `dart format .` inside `mobile/` before committing. Without Flutter installed:
+  `docker run --rm -v ${PWD}/mobile:/app -w /app dart:stable dart format .`
+- **Keep your branch up to date** with `development` before opening/merging your PR — CI runs against your branch's current state, so a stale branch can show failures that were already fixed elsewhere.
+- **Keep PRs focused**: don't mix formatting-only changes with bug fixes or new features in the same PR — it makes review and rollback much easier.
+
 ## Coding Style
 
 - Keep code readable.
@@ -86,6 +95,15 @@ Resposta.
 Descrição do que foi feito. Você pode adicionar alguma print se necessário.
 
 ```
+
+## Antes de abrir um PR
+
+- **Backend (PHP):** rode `vendor/bin/pint` antes de commitar — ele corrige o estilo de código automaticamente. Se não tiver PHP instalado, rode via Docker:
+  `docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli vendor/bin/pint`
+- **Mobile (Flutter):** rode `dart format .` dentro de `mobile/` antes de commitar. Sem Flutter instalado:
+  `docker run --rm -v ${PWD}/mobile:/app -w /app dart:stable dart format .`
+- **Mantenha sua branch atualizada** com a `development` antes de abrir/mergear o PR — o CI roda em cima do estado atual da sua branch, então uma branch desatualizada pode mostrar falhas que já foram corrigidas em outro lugar.
+- **Mantenha os PRs focados**: não misture mudanças só de formatação com correção de bug ou feature nova no mesmo PR — facilita muito a revisão e um eventual rollback.
 
 ## Padrão de código
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@ Contributors will be added here after their first accepted Pull Request.
 | Caio Vieira             | Ci & Docker    | https://linkedin.com/in/caioviier                       |
 | Willian                 | CI             | https://williancagol.vercel.app                         |
 | Caio Vinícius Ferreira  | CI             | https://linkedin.com/in/caio-vin%C3%ADcius-ferreira     |
+| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |               |
 
 ---
 
@@ -65,3 +66,4 @@ Os colaboradores serão adicionados aqui após o primeiro Pull Request aceito.
 | Caio Vieira             | Ci & Docker    | https://linkedin.com/in/caioviier                       |
 | Willian                 | CI             | https://williancagol.vercel.app                         |
 | Caio Vinícius Ferreira  | CI             | https://linkedin.com/in/caio-vin%C3%ADcius-ferreira     |
+| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |               | 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,7 @@ Contributors will be added here after their first accepted Pull Request.
 | Caio Vieira             | Ci & Docker    | https://linkedin.com/in/caioviier                       |
 | Willian                 | CI             | https://williancagol.vercel.app                         |
 | Caio Vinícius Ferreira  | CI             | https://linkedin.com/in/caio-vin%C3%ADcius-ferreira     |
-| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |               |
+| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |
 
 ---
 
@@ -66,4 +66,4 @@ Os colaboradores serão adicionados aqui após o primeiro Pull Request aceito.
 | Caio Vieira             | Ci & Docker    | https://linkedin.com/in/caioviier                       |
 | Willian                 | CI             | https://williancagol.vercel.app                         |
 | Caio Vinícius Ferreira  | CI             | https://linkedin.com/in/caio-vin%C3%ADcius-ferreira     |
-| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |               | 
+| Pedro Migliori          | React & CI     | https://www.linkedin.com/in/akamigliori/                |


### PR DESCRIPTION
**Você testou localmente?**
Não se aplica (mudança de documentação).

### O que foi feito:

Depois de arrumar o CI (#109), documenta no `CONTRIBUTING.md` (EN + PT) os passos que faltavam pra evitar quebrar o CI de novo: rodar `vendor/bin/pint`/`dart format` antes de commitar (com alternativa via Docker pra quem não tem PHP/Flutter instalados), manter a branch atualizada com `development` antes de abrir/mergear o PR, e manter PRs focados (sem misturar formatação com bugfix/feature).

Também adiciona Pedro Migliori (React & CI) em `CONTRIBUTORS.md`.
