### PR TITLE
 Feature: bot recebe CV, LinkedIn, GitHub, portfólio e habilidades extras pra gerar currículo com IA

### DIFF
--- a/bot/app/controllers/analysis_controller.py
+++ b/bot/app/controllers/analysis_controller.py
@@ -8,6 +8,11 @@ from app.models.error_response import ErrorResponse
 from app.models.resume_analysis import ResumeAnalysisRequest
 from app.providers.base import AIProviderError
 from app.services.ai.interfaces import ResumeAnalysisManagerInterface
+from app.services.parsing.interfaces import (
+    ResumeContentValidatorInterface,
+    ResumeFileFetcherInterface,
+)
+from app.services.parsing.resume_file_fetcher import UnfetchableResumeFile
 
 analysis_blueprint = Blueprint("analysis", __name__)
 
@@ -16,16 +21,60 @@ analysis_blueprint = Blueprint("analysis", __name__)
 @inject
 async def analyze(
     resume_analysis_manager: ResumeAnalysisManagerInterface = Provide[Container.resume_analysis_manager],
+    resume_file_fetcher: ResumeFileFetcherInterface = Provide[Container.resume_file_fetcher],
+    resume_content_validator: ResumeContentValidatorInterface = Provide[Container.resume_content_validator],
 ):
     payload = await quart_request.get_json(force=True, silent=True) or {}
     try:
         analysis_request = ResumeAnalysisRequest.model_validate(payload)
     except ValidationError as error:
-        return ErrorResponse(detail=error.errors()).model_dump(mode="json"), 422
+        # include_context=False: pydantic embeds the raw exception object (e.g. our
+        # own ValueError from _require_a_cv_source) in each error's `ctx`, which
+        # isn't JSON-serializable and would turn this 422 into an unhandled 500.
+        return ErrorResponse(detail=error.errors(include_context=False)).model_dump(mode="json"), 422
 
     try:
-        result = await resume_analysis_manager.extract_resume(analysis_request.resume_text)
+        resume_text = await _resolve_text(
+            resume_file_fetcher, analysis_request.resume_text, analysis_request.resume_cv_url
+        )
+        linkedin_text = await _resolve_text(
+            resume_file_fetcher, None, analysis_request.resume_linkedin_url
+        )
+    except UnfetchableResumeFile as error:
+        return ErrorResponse(detail=str(error)).model_dump(mode="json"), 422
+    except Exception:
+        return ErrorResponse(detail="could not download or read one of the file references").model_dump(mode="json"), 422
+
+    # ResumeAnalysisRequest guarantees resume_text or resume_cv_url was given,
+    # so this only fires if the URL fetch above returned an empty document.
+    if resume_text is None or not resume_text.strip():
+        return ErrorResponse(detail="empty").model_dump(mode="json"), 422
+
+    validation = resume_content_validator.validate(resume_text)
+    if not validation.is_valid:
+        return ErrorResponse(detail=validation.reason).model_dump(mode="json"), 422
+
+    try:
+        result = await resume_analysis_manager.extract_resume(
+            resume_text,
+            linkedin_text=linkedin_text,
+            github_url=analysis_request.github_url,
+            portfolio_url=analysis_request.portfolio_url,
+            additional_skills=analysis_request.additional_skills,
+        )
     except AIProviderError as error:
         return ErrorResponse(detail=str(error)).model_dump(mode="json"), 503
 
     return result.model_dump(mode="json")
+
+
+async def _resolve_text(
+    resume_file_fetcher: ResumeFileFetcherInterface, inline_text: str | None, url: str | None
+) -> str | None:
+    """Prefer inline text; fall back to downloading and extracting the given URL."""
+
+    if inline_text and inline_text.strip():
+        return inline_text
+    if not url:
+        return None
+    return await resume_file_fetcher.fetch_and_extract_text(url)

--- a/bot/app/models/resume_analysis.py
+++ b/bot/app/models/resume_analysis.py
@@ -7,7 +7,7 @@ so the worker's output can be persisted without any renaming step on the PHP sid
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 QualificationType = Literal[
     "elementary_education",
@@ -92,6 +92,9 @@ class ResumeAnalysisResult(BaseModel):
 
     score: int = Field(ge=0, le=100)
     suggestion: str
+    # Short first-person-adjacent bio/"about" paragraph, written by the AI from the
+    # given sources — not copied verbatim from the resume (most resumes don't have one).
+    professional_summary: str | None = None
     header: ResumeHeader = Field(default_factory=ResumeHeader)
     experiences: list[ExperienceItem] = Field(default_factory=list)
     projects: list[ProjectItem] = Field(default_factory=list)
@@ -105,6 +108,29 @@ class ResumeAnalysisResult(BaseModel):
 
 
 class ResumeAnalysisRequest(BaseModel):
-    """HTTP boundary request: resume text only, no job posting to match against."""
+    """HTTP boundary request: the base CV plus optional supporting sources.
 
-    resume_text: str = Field(min_length=1)
+    No job posting is involved here. The base CV can arrive as inline text or
+    as a URL the bot downloads and extracts itself (mirrors the RabbitMQ
+    worker's own file-reference handling) — exactly one of the two is
+    required. Every other source is optional supporting context that gets
+    folded into the same extraction instead of triggering a second AI call.
+    """
+
+    resume_text: str | None = None
+    resume_cv_url: str | None = None
+    resume_linkedin_url: str | None = None
+    github_url: str | None = None
+    portfolio_url: str | None = None
+    # Same shape as the output SkillItem (name + years): Laravel sends the skill
+    # name and how many years of experience the user reported for it.
+    additional_skills: list[SkillItem] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _require_a_cv_source(self) -> "ResumeAnalysisRequest":
+        has_text = bool(self.resume_text and self.resume_text.strip())
+        if not has_text and not self.resume_cv_url:
+            raise ValueError("either resume_text or resume_cv_url is required")
+        return self

--- a/bot/app/services/ai/interfaces.py
+++ b/bot/app/services/ai/interfaces.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from app.models.resume_analysis import ResumeAnalysisResult
+from app.models.resume_analysis import ResumeAnalysisResult, SkillItem
 
 if TYPE_CHECKING:
     from app.providers.base import AIProvider
@@ -23,6 +23,12 @@ class ResumeAnalysisManagerInterface(ABC):
 
     @abstractmethod
     async def extract_resume(
-        self, resume_text: str, factory: Callable[[str], AIProvider] | None = None
+        self,
+        resume_text: str,
+        factory: Callable[[str], AIProvider] | None = None,
+        linkedin_text: str | None = None,
+        github_url: str | None = None,
+        portfolio_url: str | None = None,
+        additional_skills: list[SkillItem] | None = None,
     ) -> ResumeAnalysisResult:
         ...

--- a/bot/app/services/ai/resume_analysis_manager.py
+++ b/bot/app/services/ai/resume_analysis_manager.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 
 from app.core.settings import Settings
-from app.models.resume_analysis import ResumeAnalysisResult
+from app.models.resume_analysis import ResumeAnalysisResult, SkillItem
 from app.providers.base import AIProvider, AIProviderError
 from app.providers.factory import ProviderFactory, SUPPORTED_PROVIDERS
 from app.providers.interfaces import ProviderFactoryInterface
@@ -63,12 +63,30 @@ class ResumeAnalysisManager(ResumeAnalysisManagerInterface):
         return AIProviderError(template.format(label=label), category=category, status_http=status)
 
     async def extract_resume(
-        self, resume_text: str, factory: Callable[[str], AIProvider] | None = None
+        self,
+        resume_text: str,
+        factory: Callable[[str], AIProvider] | None = None,
+        linkedin_text: str | None = None,
+        github_url: str | None = None,
+        portfolio_url: str | None = None,
+        additional_skills: list[SkillItem] | None = None,
     ) -> ResumeAnalysisResult:
-        """Try each configured provider in order, returning the first successful extraction."""
+        """Try each configured provider in order, returning the first successful extraction.
+
+        ``linkedin_text``/``github_url``/``portfolio_url``/``additional_skills`` are
+        optional supporting sources folded into the same prompt as the base resume,
+        so the AI produces one coherent result instead of the caller merging several.
+        """
 
         factory = factory or self._provider_factory.create
-        prompt = build_resume_extraction_prompt(resume_text, self._settings.ai.output_language)
+        prompt = build_resume_extraction_prompt(
+            resume_text,
+            self._settings.ai.output_language,
+            linkedin_text=linkedin_text,
+            github_url=github_url,
+            portfolio_url=portfolio_url,
+            additional_skills=additional_skills,
+        )
         last_error: AIProviderError | None = None
 
         for name in self.get_provider_chain():
@@ -83,7 +101,7 @@ class ResumeAnalysisManager(ResumeAnalysisManagerInterface):
                 continue
 
             if isinstance(result, ResumeAnalysisResult):
-                return result
+                return self._merge_known_facts(result, github_url, portfolio_url, additional_skills)
             last_error = AIProviderError(
                 f"{name.capitalize()} returned data outside the expected schema.",
                 category="schema_validation_error",
@@ -92,3 +110,37 @@ class ResumeAnalysisManager(ResumeAnalysisManagerInterface):
         raise last_error or AIProviderError(
             "No AI provider is configured.", category="missing_api_key"
         )
+
+    def _merge_known_facts(
+        self,
+        result: ResumeAnalysisResult,
+        github_url: str | None,
+        portfolio_url: str | None,
+        additional_skills: list[SkillItem] | None,
+    ) -> ResumeAnalysisResult:
+        """Force in values we already know exactly, regardless of what the AI did with them.
+
+        The prompt already asks the AI to place these, but instruction-following isn't
+        guaranteed — GitHub/portfolio links and user-typed skills are known facts, not
+        something that needs to be inferred, so they must never depend on the AI
+        transcribing them correctly.
+        """
+
+        if github_url:
+            result.header.links["GitHub"] = github_url
+        if portfolio_url:
+            result.header.links["Portfolio"] = portfolio_url
+        if additional_skills:
+            by_name = {skill.name.strip().lower(): skill for skill in result.skills}
+            for reported in additional_skills:
+                key = reported.name.strip().lower()
+                existing = by_name.get(key)
+                if existing is not None:
+                    # The user's own reported years take precedence over the AI's guess.
+                    if reported.years is not None:
+                        existing.years = reported.years
+                else:
+                    new_skill = SkillItem(name=reported.name, years=reported.years)
+                    result.skills.append(new_skill)
+                    by_name[key] = new_skill
+        return result

--- a/bot/app/services/ai/resume_extraction_prompt.py
+++ b/bot/app/services/ai/resume_extraction_prompt.py
@@ -3,20 +3,56 @@
 import json
 from datetime import date
 
-from app.models.resume_analysis import ResumeAnalysisResult
+from app.models.resume_analysis import ResumeAnalysisResult, SkillItem
 
 
-def build_resume_extraction_prompt(resume_text: str, output_language: str = "pt-BR") -> str:
+def build_resume_extraction_prompt(
+    resume_text: str,
+    output_language: str = "pt-BR",
+    linkedin_text: str | None = None,
+    github_url: str | None = None,
+    portfolio_url: str | None = None,
+    additional_skills: list[SkillItem] | None = None,
+) -> str:
     schema = ResumeAnalysisResult.model_json_schema()
-    return (
+    instructions = (
         f"Today's date is {date.today().isoformat()}. "
-        "You are an ATS and resume-writing expert. Read the resume text below and "
-        "extract its structured data faithfully — do not invent, infer, or complete "
-        "any information that is not actually present in the text. Leave a field "
-        "null (or an empty list) when the resume does not state it. "
+        "You are an ATS and resume-writing expert. Read the resume text below — and "
+        "the supporting sources after it, if any — and extract structured data "
+        "faithfully — do not invent, infer, or complete any information that is not "
+        "actually present in the given sources. Leave a field null (or an empty list) "
+        "when nothing states it. When the LinkedIn text repeats or extends the resume, "
+        "merge them into a single coherent set of experiences/qualifications instead of "
+        "duplicating entries. Also write a short (2-4 sentence) professional_summary: "
+        "an \"about this person\" bio synthesized from the facts actually present in the "
+        "given sources (role, seniority, main skills, standout experience) — composing "
+        "it is expected even when no source has a literal bio paragraph, but every "
+        "claim in it must still be grounded in the given sources, never fabricated. "
         "Also produce a 0-100 score for how well-written and ATS-friendly the resume "
         "is, and one direct, actionable improvement suggestion. "
-        f"Write the suggestion in {output_language}. "
-        f"Return only valid JSON matching this schema: {json.dumps(schema, ensure_ascii=False)} "
-        f"Resume text:\n{resume_text}"
+        f"Write the professional_summary and the suggestion in {output_language}. "
+        f"Return only valid JSON matching this schema: {json.dumps(schema, ensure_ascii=False)}"
     )
+
+    sources = [f"Resume text:\n{resume_text}"]
+    if linkedin_text:
+        sources.append(f"LinkedIn resume text:\n{linkedin_text}")
+    if github_url:
+        sources.append(
+            f"User's GitHub link (add it to header.links under the key \"GitHub\"): {github_url}"
+        )
+    if portfolio_url:
+        sources.append(
+            f"User's portfolio link (add it to header.links under the key \"Portfolio\"): {portfolio_url}"
+        )
+    if additional_skills:
+        skills_list = ", ".join(
+            f"{skill.name} ({skill.years} anos)" if skill.years is not None else skill.name
+            for skill in additional_skills
+        )
+        sources.append(
+            f"Additional skills reported by the user, to merge into the skills list "
+            f"(name and years of experience): {skills_list}"
+        )
+
+    return instructions + "\n\n" + "\n\n".join(sources)

--- a/bot/tests/test_health.py
+++ b/bot/tests/test_health.py
@@ -24,18 +24,28 @@ def test_health_behavior_01() -> None:
 
 
 class FakeResumeAnalysisManager:
-    async def extract_resume(self, resume_text: str) -> ResumeAnalysisResult:
-        return ResumeAnalysisResult(score=80, suggestion="Adicione métricas de impacto.")
+    async def extract_resume(self, resume_text: str, **_kwargs) -> ResumeAnalysisResult:
+        return ResumeAnalysisResult(
+            score=80,
+            suggestion="Adicione métricas de impacto.",
+            professional_summary="Desenvolvedor backend com foco em Python e APIs REST.",
+        )
 
 
 def test_analyze_endpoint_returns_structured_result() -> None:
     app.container.resume_analysis_manager.override(providers.Object(FakeResumeAnalysisManager()))
+    resume_text = (
+        "Desenvolvedor backend com experiência em Python, FastAPI e SQL. "
+        "Atuou em projetos de automação de currículos, integração com filas de "
+        "mensagens e construção de APIs REST para times de produto. Formação em "
+        "Ciência da Computação e experiência prévia como estagiário de TI."
+    )
     try:
         response = asyncio.run(
             request_app(
                 "POST",
                 "/api/v1/analyze",
-                json={"resume_text": "Python and FastAPI project experience."},
+                json={"resume_text": resume_text},
             )
         )
     finally:
@@ -45,9 +55,128 @@ def test_analyze_endpoint_returns_structured_result() -> None:
     result = response.json()
     assert result["score"] == 80
     assert result["suggestion"] == "Adicione métricas de impacto."
+    assert result["professional_summary"] == "Desenvolvedor backend com foco em Python e APIs REST."
 
 
 def test_analyze_endpoint_rejects_empty_resume_text() -> None:
     response = asyncio.run(request_app("POST", "/api/v1/analyze", json={"resume_text": ""}))
+
+    assert response.status_code == 422
+
+
+def test_analyze_endpoint_rejects_missing_resume_source() -> None:
+    """Neither resume_text nor resume_cv_url given: 422, not a 500."""
+    response = asyncio.run(
+        request_app("POST", "/api/v1/analyze", json={"github_url": "https://github.com/foo"})
+    )
+
+    assert response.status_code == 422
+
+
+BASE_RESUME_TEXT = (
+    "Desenvolvedor backend com experiência em Python, FastAPI e SQL. Atuou em "
+    "projetos de automação de currículos, integração com filas de mensagens e "
+    "construção de APIs REST para times de produto. Formação em Ciência da "
+    "Computação e experiência prévia como estagiário de TI."
+)
+
+
+class SpyResumeAnalysisManager:
+    """Captures every argument extract_resume was called with, for assertion."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def extract_resume(self, resume_text: str, **kwargs) -> ResumeAnalysisResult:
+        self.calls.append({"resume_text": resume_text, **kwargs})
+        return ResumeAnalysisResult(score=80, suggestion="Adicione métricas de impacto.")
+
+
+def test_analyze_endpoint_forwards_every_supporting_source() -> None:
+    spy = SpyResumeAnalysisManager()
+    app.container.resume_analysis_manager.override(providers.Object(spy))
+    try:
+        response = asyncio.run(
+            request_app(
+                "POST",
+                "/api/v1/analyze",
+                json={
+                    "resume_text": BASE_RESUME_TEXT,
+                    "github_url": "https://github.com/pedroaruana",
+                    "portfolio_url": "https://pedroaruana.dev",
+                    "additional_skills": [{"name": "React", "years": 2}, {"name": "Docker"}],
+                },
+            )
+        )
+    finally:
+        app.container.resume_analysis_manager.reset_override()
+
+    assert response.status_code == 200
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    assert call["resume_text"] == BASE_RESUME_TEXT
+    assert call["github_url"] == "https://github.com/pedroaruana"
+    assert call["portfolio_url"] == "https://pedroaruana.dev"
+    assert [(skill.name, skill.years) for skill in call["additional_skills"]] == [
+        ("React", 2),
+        ("Docker", None),
+    ]
+
+
+class FakeResumeFileFetcher:
+    def __init__(self, text_by_url: dict[str, str]) -> None:
+        self._text_by_url = text_by_url
+
+    async def fetch_and_extract_text(self, url: str) -> str:
+        return self._text_by_url[url]
+
+
+def test_analyze_endpoint_fetches_cv_and_linkedin_from_url() -> None:
+    spy = SpyResumeAnalysisManager()
+    fetcher = FakeResumeFileFetcher(
+        {
+            "https://files.example.com/cv.pdf": BASE_RESUME_TEXT,
+            "https://files.example.com/linkedin.pdf": "Resumo do LinkedIn com experiência extra.",
+        }
+    )
+    app.container.resume_analysis_manager.override(providers.Object(spy))
+    app.container.resume_file_fetcher.override(providers.Object(fetcher))
+    try:
+        response = asyncio.run(
+            request_app(
+                "POST",
+                "/api/v1/analyze",
+                json={
+                    "resume_cv_url": "https://files.example.com/cv.pdf",
+                    "resume_linkedin_url": "https://files.example.com/linkedin.pdf",
+                },
+            )
+        )
+    finally:
+        app.container.resume_analysis_manager.reset_override()
+        app.container.resume_file_fetcher.reset_override()
+
+    assert response.status_code == 200
+    call = spy.calls[0]
+    assert call["resume_text"] == BASE_RESUME_TEXT
+    assert call["linkedin_text"] == "Resumo do LinkedIn com experiência extra."
+
+
+def test_analyze_endpoint_returns_422_when_cv_url_cannot_be_fetched() -> None:
+    class FailingFetcher:
+        async def fetch_and_extract_text(self, url: str) -> str:
+            raise RuntimeError("boom")
+
+    app.container.resume_file_fetcher.override(providers.Object(FailingFetcher()))
+    try:
+        response = asyncio.run(
+            request_app(
+                "POST",
+                "/api/v1/analyze",
+                json={"resume_cv_url": "https://files.example.com/cv.pdf"},
+            )
+        )
+    finally:
+        app.container.resume_file_fetcher.reset_override()
 
     assert response.status_code == 422

--- a/bot/tests/test_resume_analysis_manager.py
+++ b/bot/tests/test_resume_analysis_manager.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from app.models.resume_analysis import ResumeAnalysisResult
+from app.models.resume_analysis import ResumeAnalysisResult, ResumeHeader, SkillItem
 from app.providers.base import AIProviderError
 from app.providers.mock import MockProvider
 from app.services.ai.resume_analysis_manager import ResumeAnalysisManager
@@ -153,3 +153,68 @@ def test_provider_failure_is_sanitized(monkeypatch, category, status) -> None:
     assert captured.value.category == category
     assert captured.value.status_http == status
     assert "detail interno" not in str(captured.value)
+
+
+def test_merges_github_and_portfolio_into_header_links_regardless_of_ai_output(monkeypatch) -> None:
+    """Known-exact values must land correctly even if the AI ignores/misplaces them."""
+    monkeypatch.setenv("IA_PROVIDER", "groq")
+    monkeypatch.setenv("GROQ_API_KEY", "chave-ficticia-para-teste")
+
+    ai_result = ResumeAnalysisResult(
+        score=70, suggestion="ok", header=ResumeHeader(links={"Other": "https://example.com"})
+    )
+
+    result = asyncio.run(
+        ResumeAnalysisManager().extract_resume(
+            RESUME_TEXT,
+            lambda name: MockProvider(structured_response=ai_result),
+            github_url="https://github.com/pedroaruana",
+            portfolio_url="https://pedroaruana.dev",
+        )
+    )
+
+    assert result.header.links["GitHub"] == "https://github.com/pedroaruana"
+    assert result.header.links["Portfolio"] == "https://pedroaruana.dev"
+    assert result.header.links["Other"] == "https://example.com"
+
+
+def test_merges_additional_skills_without_duplicating_existing_ones(monkeypatch) -> None:
+    monkeypatch.setenv("IA_PROVIDER", "groq")
+    monkeypatch.setenv("GROQ_API_KEY", "chave-ficticia-para-teste")
+
+    ai_result = ResumeAnalysisResult(
+        score=70, suggestion="ok", skills=[SkillItem(name="Python"), SkillItem(name="docker")]
+    )
+
+    result = asyncio.run(
+        ResumeAnalysisManager().extract_resume(
+            RESUME_TEXT,
+            lambda name: MockProvider(structured_response=ai_result),
+            additional_skills=[SkillItem(name="Docker", years=3), SkillItem(name="GraphQL", years=1)],
+        )
+    )
+
+    names = sorted(skill.name.lower() for skill in result.skills)
+    assert names == ["docker", "graphql", "python"]
+
+
+def test_additional_skill_years_overrides_ai_guess_for_an_existing_skill(monkeypatch) -> None:
+    """Laravel sends name + years per skill (e.g. PHP -> 5 anos); the user's own number wins."""
+    monkeypatch.setenv("IA_PROVIDER", "groq")
+    monkeypatch.setenv("GROQ_API_KEY", "chave-ficticia-para-teste")
+
+    ai_result = ResumeAnalysisResult(
+        score=70, suggestion="ok", skills=[SkillItem(name="PHP", years=2)]
+    )
+
+    result = asyncio.run(
+        ResumeAnalysisManager().extract_resume(
+            RESUME_TEXT,
+            lambda name: MockProvider(structured_response=ai_result),
+            additional_skills=[SkillItem(name="PHP", years=5)],
+        )
+    )
+
+    php_skills = [skill for skill in result.skills if skill.name.lower() == "php"]
+    assert len(php_skills) == 1
+    assert php_skills[0].years == 5


### PR DESCRIPTION
Resolve a issue #139

- bot agora aceita numa análise só: pdf do currículo (obrigatório, texto ou url), 
  pdf do linkedin, link do github, link do portfólio e habilidades extras (nome + anos)
- gera: dados pessoais/contato (com github e portfólio), resumo profissional, 
  experiências, cursos/estudos e idiomas
- melhoria: github, portfólio e habilidades extras são garantidos direto no código 
  depois que a IA responde, não dependem só de instrução no prompt
- não muda o formato que o laravel já espera receber

## Uso de IA

- [x] Vibe-code
- [ ] Pesquisa

## Tipo de mudança

- [ ] Bug fix
- [x] Nova feature
- [ ] Breaking change
- [ ] Documentação
- [ ] Chore / infra

## Área afetada

- [ ] frontend
- [ ] backend
- [ ] mobile
- [x] bot
- [ ] CI/CD

## Checklist

- [x] Testei localmente
- [x] Adicionei/atualizei testes quando necessário
- [ ] `npm run lint` / `vendor/bin/pint` / `flutter analyze` passando
- [ ] Atualizei a documentação quando necessário



## Como testar

1. entra na pasta bot
2. copia config.yaml.example pra config.yaml
3. roda uv sync
4. roda uv run pytest
5. deve mostrar 79 testes passando

<img width="1039" height="535" alt="Captura de tela 2026-07-18 204810" src="https://github.com/user-attachments/assets/5a6faeac-684b-40af-bbf6-5398aaf26971" />