### PR TITLE
Feature: adiciona CI automático pro bot (roda os testes em cada PR)

### DIFF
--- a/.github/workflows/bot-ci.yml
+++ b/.github/workflows/bot-ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.11"
 

--- a/.github/workflows/bot-ci.yml
+++ b/.github/workflows/bot-ci.yml
@@ -1,0 +1,43 @@
+name: Bot CI
+
+on:
+  push:
+    branches: [main, development]
+    paths:
+      - "bot/**"
+      - ".github/workflows/bot-ci.yml"
+  pull_request:
+    branches: [main, development]
+    paths:
+      - "bot/**"
+      - ".github/workflows/bot-ci.yml"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: bot
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          python-version: "3.11"
+
+      - name: Copy config.yaml
+        run: cp config.yaml.example config.yaml
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Descrição

Resolve a issue #138
- o bot já tinha 79 testes escritos (pytest), mas não rodava sozinho em lugar nenhum
- adicionei o workflow bot-ci.yml, no mesmo padrão do backend-ci.yml e frontend-ci.yml
- roda automático em todo push/PR que mexer na pasta bot/

## Uso de IA

- [x] Vibe-code
- [ ] Pesquisa

## Tipo de mudança

- [ ] Bug fix
- [ ] Nova feature
- [ ] Breaking change
- [ ] Documentação
- [x] Chore / infra

## Área afetada

- [ ] frontend
- [ ] backend
- [ ] mobile
- [ ] bot
- [x] CI/CD

## Checklist
- [x] Testei localmente
- [ ] Adicionei/atualizei testes quando necessário
- [ ] `npm run lint` / `vendor/bin/pint` / `flutter analyze` passando
- [ ] Atualizei a documentação quando necessário

## Como testar

1. abrir esse PR
2. ver o check "Bot CI" rodando e passando sozinho

<img width="1038" height="466" alt="Captura de tela 2026-07-18 230831" src="https://github.com/user-attachments/assets/1922306f-70c8-4c4c-8034-95501e75bc5e" />