### PR TITLE
docs(backend): documenta endpoints da API com Swagger (l5-swagger)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -102,3 +102,45 @@ jobs:
 
       - name: Run Pint (dry-run)
         run: vendor/bin/pint --test
+
+  docs:
+    name: API docs (OpenAPI lint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: mbstring, dom, fileinfo, sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: backend/vendor
+          key: composer-${{ hashFiles('backend/composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Generate app key
+        run: php artisan key:generate
+
+      - name: Generate OpenAPI spec
+        run: php artisan l5-swagger:generate
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Lint OpenAPI spec
+        run: npx --yes @redocly/cli lint storage/api-docs/api-docs.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,13 @@ Description of what you have fixed. You can also upload screenshots if needed.
   `docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli vendor/bin/pint`
 - **Mobile (Flutter):** run `dart format .` inside `mobile/` before committing. Without Flutter installed:
   `docker run --rm -v ${PWD}/mobile:/app -w /app dart:stable dart format .`
+- **Backend (API docs):** if you add, remove, or change an endpoint under `backend/app/Http/Controllers/Api/**`, update its Swagger attributes (`#[OpenApi\Attributes\...]`) and regenerate/lint the spec before committing:
+  `cd backend && php artisan l5-swagger:generate && npx --yes @redocly/cli lint storage/api-docs/api-docs.json`
+  This is the same check the "API docs (OpenAPI lint)" CI job runs, so catching it locally avoids a failed PR. If you don't have PHP/Node installed, run it via Docker instead:
+  ```
+  docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli php artisan l5-swagger:generate
+  docker run --rm -v ${PWD}/backend:/app -w /app node:22 npx --yes @redocly/cli lint storage/api-docs/api-docs.json
+  ```
 - **Keep your branch up to date** with `development` before opening/merging your PR — CI runs against your branch's current state, so a stale branch can show failures that were already fixed elsewhere.
 - **Keep PRs focused**: don't mix formatting-only changes with bug fixes or new features in the same PR — it makes review and rollback much easier.
 
@@ -102,6 +109,13 @@ Descrição do que foi feito. Você pode adicionar alguma print se necessário.
   `docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli vendor/bin/pint`
 - **Mobile (Flutter):** rode `dart format .` dentro de `mobile/` antes de commitar. Sem Flutter instalado:
   `docker run --rm -v ${PWD}/mobile:/app -w /app dart:stable dart format .`
+- **Backend (documentação da API):** se você adicionar, remover ou alterar um endpoint em `backend/app/Http/Controllers/Api/**`, atualize os atributos de Swagger (`#[OpenApi\Attributes\...]`) e regenere/lint a spec antes de commitar:
+  `cd backend && php artisan l5-swagger:generate && npx --yes @redocly/cli lint storage/api-docs/api-docs.json`
+  É a mesma checagem que o job "API docs (OpenAPI lint)" do CI roda, então pegar isso localmente evita um PR falhando. Se não tiver PHP/Node instalado, rode via Docker:
+  ```
+  docker run --rm -v ${PWD}/backend:/app -w /app php:8.4-cli php artisan l5-swagger:generate
+  docker run --rm -v ${PWD}/backend:/app -w /app node:22 npx --yes @redocly/cli lint storage/api-docs/api-docs.json
+  ```
 - **Mantenha sua branch atualizada** com a `development` antes de abrir/mergear o PR — o CI roda em cima do estado atual da sua branch, então uma branch desatualizada pode mostrar falhas que já foram corrigidas em outro lugar.
 - **Mantenha os PRs focados**: não misture mudanças só de formatação com correção de bug ou feature nova no mesmo PR — facilita muito a revisão e um eventual rollback.
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,3 +27,4 @@ Homestead.yaml
 Thumbs.db
 composer.lock
 /storage/app/*
+/storage/api-docs

--- a/backend/app/Http/Controllers/Api/Auth/AuthController.php
+++ b/backend/app/Http/Controllers/Api/Auth/AuthController.php
@@ -18,9 +18,70 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OAT;
 
 class AuthController extends Controller
 {
+    #[OAT\Post(
+        path: '/auth/login',
+        summary: 'Autentica um usuário',
+        security: [],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: true,
+            content: new OAT\JsonContent(
+                required: ['email', 'password'],
+                properties: [
+                    new OAT\Property(property: 'email', type: 'string', format: 'email', example: 'user@example.com'),
+                    new OAT\Property(property: 'password', type: 'string', format: 'password', example: 'secret123'),
+                    new OAT\Property(property: 'fcm', type: 'string', nullable: true, description: 'Token FCM do dispositivo, para notificações push'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Login realizado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Login successful'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'token', type: 'string'),
+                                new OAT\Property(property: 'user', type: 'object'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(
+                response: 401,
+                description: 'Credenciais inválidas',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 401),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Invalid credentials'),
+                        new OAT\Property(property: 'data', type: 'array', items: new OAT\Items(type: 'string'), example: ['Email or password is incorrect']),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 422, description: 'Erro de validação', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao autenticar',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Login failed'),
+                        new OAT\Property(property: 'data', type: 'array', items: new OAT\Items(type: 'string'), example: ['SQLSTATE[HY000]...']),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function login(LoginRequest $request)
     {
         try {
@@ -54,6 +115,60 @@ class AuthController extends Controller
         }
     }
 
+    #[OAT\Post(
+        path: '/auth/register',
+        summary: 'Registra um novo usuário',
+        security: [],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: true,
+            content: new OAT\JsonContent(
+                required: ['name', 'email', 'password', 'password_confirm'],
+                properties: [
+                    new OAT\Property(property: 'name', type: 'string', example: 'João da Silva'),
+                    new OAT\Property(property: 'email', type: 'string', format: 'email', example: 'user@example.com'),
+                    new OAT\Property(property: 'password', type: 'string', format: 'password', example: 'secret123'),
+                    new OAT\Property(property: 'password_confirm', type: 'string', format: 'password', example: 'secret123'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 201,
+                description: 'Usuário registrado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 201),
+                        new OAT\Property(property: 'message', type: 'string', example: 'User registered successfully'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'token', type: 'string'),
+                                new OAT\Property(property: 'user', type: 'object'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 422, description: 'Erro de validação (e-mail já em uso, senhas não conferem, etc.)', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao registrar',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Registration failed'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function register(RegisterRequest $request)
     {
 
@@ -87,6 +202,33 @@ class AuthController extends Controller
 
     }
 
+    #[OAT\Post(
+        path: '/auth/logout',
+        summary: 'Encerra a sessão do usuário autenticado',
+        security: [['bearerAuth' => []]],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: false,
+            content: new OAT\JsonContent(
+                properties: [
+                    new OAT\Property(property: 'fcm', type: 'string', nullable: true, description: 'Token FCM do dispositivo a ser removido'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Logout realizado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Logged out successfully'),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+        ]
+    )]
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
@@ -98,6 +240,56 @@ class AuthController extends Controller
         return ResponseData::success('Logged out successfully');
     }
 
+    #[OAT\Post(
+        path: '/auth/forgot-password',
+        summary: 'Envia um código OTP por e-mail para redefinição de senha',
+        security: [],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: true,
+            content: new OAT\JsonContent(
+                required: ['email'],
+                properties: [
+                    new OAT\Property(property: 'email', type: 'string', format: 'email', example: 'user@example.com'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'OTP enviado com sucesso para o e-mail informado',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'OTP sent successfully to the provided email'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'expires_at', type: 'string', format: 'date-time'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 422, description: 'E-mail não encontrado ou inválido', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao processar a solicitação',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Forgot password failed'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function forgotPassword(ForgotPasswordRequest $request)
     {
         try {
@@ -131,6 +323,72 @@ class AuthController extends Controller
         }
     }
 
+    #[OAT\Post(
+        path: '/auth/verify-otp',
+        summary: 'Verifica se um código OTP é válido',
+        security: [],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: true,
+            content: new OAT\JsonContent(
+                required: ['otp'],
+                properties: [
+                    new OAT\Property(property: 'otp', type: 'string', example: '123456', description: 'Código de 6 dígitos enviado por e-mail'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'OTP válido',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Valid'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'message', type: 'string'),
+                                new OAT\Property(property: 'user_id', type: 'integer'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(
+                response: 400,
+                description: 'OTP inválido ou expirado',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 400),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Invalid or expired OTP'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string', example: 'The provided OTP is either invalid or has expired.')]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 422, description: 'Erro de validação', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao verificar o OTP',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'OTP verification failed'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function verifyOtp(VerifyOtpRequest $request)
     {
         try {
@@ -160,6 +418,51 @@ class AuthController extends Controller
         }
     }
 
+    #[OAT\Post(
+        path: '/auth/reset-password',
+        summary: 'Redefine a senha do usuário usando um OTP já verificado',
+        security: [],
+        tags: ['Auth'],
+        requestBody: new OAT\RequestBody(
+            required: true,
+            content: new OAT\JsonContent(
+                required: ['otp', 'password', 'password_confirm'],
+                properties: [
+                    new OAT\Property(property: 'otp', type: 'string', example: '123456'),
+                    new OAT\Property(property: 'password', type: 'string', format: 'password', example: 'newSecret123'),
+                    new OAT\Property(property: 'password_confirm', type: 'string', format: 'password', example: 'newSecret123'),
+                ]
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Senha redefinida com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Password reset successfully'),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 422, description: 'Erro de validação (OTP inválido, senhas não conferem, etc.)', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao redefinir a senha',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Password reset failed'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function resetPassword(ResetPasswordRequest $request)
     {
 
@@ -187,6 +490,32 @@ class AuthController extends Controller
 
     }
 
+    #[OAT\Get(
+        path: '/client/user',
+        summary: 'Retorna os dados do usuário autenticado',
+        security: [['bearerAuth' => []]],
+        tags: ['Auth'],
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Usuário retornado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'User retrieved successfully'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'user', type: 'object'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+        ]
+    )]
     public function user(Request $request)
     {
         return ResponseData::success('User retrieved successfully', [

--- a/backend/app/Http/Controllers/Api/Resume/ResumeController.php
+++ b/backend/app/Http/Controllers/Api/Resume/ResumeController.php
@@ -13,11 +13,80 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OAT;
 
 class ResumeController extends Controller
 {
     use UserProcessRelationsTrait, UserUploadsTrait;
 
+    #[OAT\Post(
+        path: '/client/resumes/new-resume',
+        summary: 'Envia um novo currículo (CV e/ou export do LinkedIn) e atualiza os dados do usuário',
+        security: [['bearerAuth' => []]],
+        tags: ['Resume'],
+        requestBody: new OAT\RequestBody(
+            required: false,
+            content: new OAT\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OAT\Schema(
+                    properties: [
+                        new OAT\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'Arquivo do currículo (pdf, doc ou docx)'),
+                        new OAT\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'Export do PDF do LinkedIn'),
+                        new OAT\Property(property: 'github_link', type: 'string', nullable: true),
+                        new OAT\Property(property: 'site_link', type: 'string', nullable: true),
+                        new OAT\Property(
+                            property: 'skills',
+                            type: 'array',
+                            nullable: true,
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'name', type: 'string'),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Currículo processado e usuário atualizado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'User Updated'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'message', type: 'string', example: 'User and upload has been updated.'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+            new OAT\Response(response: 422, description: 'Erro de validação', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao processar o currículo',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Server Error'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'errors', type: 'string', description: 'Mensagem da exceção (nota: aqui é uma string, diferente do padrão {error: string} usado no restante da API)'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function storeNewResume(NewResumeRequest $request)
     {
 
@@ -67,6 +136,56 @@ class ResumeController extends Controller
         }
     }
 
+    #[OAT\Get(
+        path: '/client/resumes/files',
+        summary: 'Gera uma URL temporária para download de um arquivo do usuário (CV, LinkedIn ou certificado PCD)',
+        security: [['bearerAuth' => []]],
+        tags: ['Resume'],
+        parameters: [
+            new OAT\Parameter(
+                name: 'type',
+                in: 'query',
+                required: false,
+                description: 'Tipo de arquivo desejado. Padrão: cv',
+                schema: new OAT\Schema(type: 'string', enum: ['cv', 'linkedin', 'pcd'], default: 'cv')
+            ),
+        ],
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'URL temporária gerada com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'success'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'file_url', type: 'string', format: 'uri'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+            new OAT\Response(
+                response: 404,
+                description: 'Arquivo não encontrado',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 404),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Not Found'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string', example: 'The requested file has not found.')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function getResumesFiles(Request $request)
     {
         $user = $request->user();
@@ -93,6 +212,30 @@ class ResumeController extends Controller
 
     }
 
+    #[OAT\Get(
+        path: '/client/resumes/pendings',
+        summary: 'Lista as análises de currículo (pendentes ou concluídas) do usuário autenticado',
+        security: [['bearerAuth' => []]],
+        tags: ['Resume'],
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Lista de análises retornada com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Success'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'array',
+                            items: new OAT\Items(type: 'object')
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+        ]
+    )]
     public function resumeAnalytics(Request $request)
     {
         return ResponseData::success(
@@ -102,6 +245,50 @@ class ResumeController extends Controller
         );
     }
 
+    #[OAT\Get(
+        path: '/client/resumes/pendings/{resume}',
+        summary: 'Retorna os detalhes de uma análise de currículo específica do usuário autenticado',
+        security: [['bearerAuth' => []]],
+        tags: ['Resume'],
+        parameters: [
+            new OAT\Parameter(
+                name: 'resume',
+                in: 'path',
+                required: true,
+                description: 'ID da análise de currículo (ResumeAnalytic)',
+                schema: new OAT\Schema(type: 'integer')
+            ),
+        ],
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Análise de currículo retornada com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Success'),
+                        new OAT\Property(property: 'data', type: 'object'),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+            new OAT\Response(
+                response: 404,
+                description: 'Análise não encontrada ou pertence a outro usuário',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 404),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Not found'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string', example: 'Resume not found')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function showPendingResume(Request $request, int $resume)
     {
 

--- a/backend/app/Http/Controllers/Api/User/UserController.php
+++ b/backend/app/Http/Controllers/Api/User/UserController.php
@@ -10,11 +10,144 @@ use App\Http\Controllers\Controller;
 use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OAT;
 
 class UserController extends Controller
 {
     use UserProcessRelationsTrait, UserUploadsTrait;
 
+    #[OAT\Put(
+        path: '/client/user/update',
+        summary: 'Atualiza os dados do usuário autenticado, incluindo currículo, habilidades, experiências, qualificações, idiomas e projetos',
+        security: [['bearerAuth' => []]],
+        tags: ['User'],
+        requestBody: new OAT\RequestBody(
+            required: false,
+            content: new OAT\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OAT\Schema(
+                    properties: [
+                        new OAT\Property(property: 'name', type: 'string', example: 'João da Silva'),
+                        new OAT\Property(property: 'password', type: 'string', format: 'password'),
+                        new OAT\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'Arquivo do currículo (pdf, doc ou docx)'),
+                        new OAT\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'Export do PDF do LinkedIn'),
+                        new OAT\Property(property: 'path_certificate_pcd', type: 'string', format: 'binary', nullable: true),
+                        new OAT\Property(property: 'github_link', type: 'string', nullable: true),
+                        new OAT\Property(property: 'site_link', type: 'string', nullable: true),
+                        new OAT\Property(property: 'linkedin_link', type: 'string', nullable: true),
+                        new OAT\Property(property: 'social_name', type: 'string', nullable: true),
+                        new OAT\Property(property: 'phone', type: 'string', nullable: true),
+                        new OAT\Property(property: 'resume_email', type: 'string', format: 'email', nullable: true),
+                        new OAT\Property(property: 'gender', type: 'string', nullable: true, description: 'Ver enum UserGenderEnum'),
+                        new OAT\Property(property: 'is_pcd', type: 'boolean', nullable: true),
+                        new OAT\Property(property: 'city', type: 'string', nullable: true),
+                        new OAT\Property(property: 'state', type: 'string', nullable: true),
+                        new OAT\Property(property: 'country', type: 'string', nullable: true),
+                        new OAT\Property(
+                            property: 'skills',
+                            type: 'array',
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'name', type: 'string'),
+                                    new OAT\Property(property: 'years', type: 'string', nullable: true),
+                                ]
+                            )
+                        ),
+                        new OAT\Property(
+                            property: 'experiences',
+                            type: 'array',
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'company', type: 'string'),
+                                    new OAT\Property(property: 'role', type: 'string'),
+                                    new OAT\Property(property: 'start', type: 'string', format: 'date'),
+                                    new OAT\Property(property: 'end', type: 'string', format: 'date', nullable: true),
+                                    new OAT\Property(property: 'description', type: 'string', nullable: true),
+                                    new OAT\Property(property: 'is_actual', type: 'boolean'),
+                                    new OAT\Property(property: 'city', type: 'string', nullable: true),
+                                    new OAT\Property(property: 'state', type: 'string', nullable: true),
+                                    new OAT\Property(property: 'country', type: 'string', nullable: true),
+                                ]
+                            )
+                        ),
+                        new OAT\Property(
+                            property: 'qualifications',
+                            type: 'array',
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'type', type: 'string', description: 'Ver enum UserQualificationTypeEnum'),
+                                    new OAT\Property(property: 'institution', type: 'string'),
+                                    new OAT\Property(property: 'title', type: 'string'),
+                                    new OAT\Property(property: 'start', type: 'string', format: 'date'),
+                                    new OAT\Property(property: 'end', type: 'string', format: 'date', nullable: true),
+                                    new OAT\Property(property: 'is_coursing', type: 'boolean'),
+                                ]
+                            )
+                        ),
+                        new OAT\Property(
+                            property: 'languages',
+                            type: 'array',
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'level', type: 'string', description: 'Ver enum UserLanguageLevelEnum'),
+                                    new OAT\Property(property: 'language', type: 'string'),
+                                ]
+                            )
+                        ),
+                        new OAT\Property(
+                            property: 'projects',
+                            type: 'array',
+                            items: new OAT\Items(
+                                properties: [
+                                    new OAT\Property(property: 'title', type: 'string'),
+                                    new OAT\Property(property: 'date', type: 'string', description: 'Ano com 4 dígitos'),
+                                    new OAT\Property(property: 'technologies', type: 'string'),
+                                    new OAT\Property(property: 'description', type: 'string'),
+                                    new OAT\Property(property: 'url', type: 'string'),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Usuário atualizado com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Success'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(property: 'user', type: 'object'),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+            new OAT\Response(response: 422, description: 'Erro de validação', content: new OAT\JsonContent(ref: '#/components/schemas/ValidationErrorResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao atualizar o usuário',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Server error'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function update(UpdateUserRequest $request)
     {
 

--- a/backend/app/Http/Controllers/Api/User/UserResumeController.php
+++ b/backend/app/Http/Controllers/Api/User/UserResumeController.php
@@ -7,9 +7,55 @@ use App\Http\Controllers\Controller;
 use App\Models\UserResume;
 use Exception;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OAT;
 
 class UserResumeController extends Controller
 {
+    #[OAT\Get(
+        path: '/client/user/resumes',
+        summary: 'Lista os currículos gerados do usuário autenticado, do mais recente para o mais antigo',
+        security: [['bearerAuth' => []]],
+        tags: ['User'],
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Lista de currículos retornada com sucesso',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 200),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Success'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [
+                                new OAT\Property(
+                                    property: 'data',
+                                    type: 'array',
+                                    items: new OAT\Items(type: 'object')
+                                ),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OAT\Response(response: 401, description: 'Não autenticado', content: new OAT\JsonContent(ref: '#/components/schemas/UnauthenticatedResponse')),
+            new OAT\Response(
+                response: 500,
+                description: 'Erro interno ao listar os currículos',
+                content: new OAT\JsonContent(
+                    properties: [
+                        new OAT\Property(property: 'code', type: 'integer', example: 500),
+                        new OAT\Property(property: 'message', type: 'string', example: 'Server error'),
+                        new OAT\Property(
+                            property: 'data',
+                            type: 'object',
+                            properties: [new OAT\Property(property: 'error', type: 'string')]
+                        ),
+                    ]
+                )
+            ),
+        ]
+    )]
     public function __invoke(Request $request)
     {
         try {

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -2,6 +2,50 @@
 
 namespace App\Http\Controllers;
 
+use OpenApi\Attributes as OAT;
+
+#[OAT\Info(
+    title: 'Bom Currículo API',
+    version: '1.0.0',
+    description: 'API para geração e gestão de currículos com IA'
+)]
+#[OAT\Server(url: '/api', description: 'Servidor da API')]
+#[OAT\SecurityScheme(
+    securityScheme: 'bearerAuth',
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'Sanctum Token'
+)]
+#[OAT\Schema(
+    schema: 'ValidationErrorResponse',
+    description: 'Erro de validação de um FormRequest. Todo FormRequest da API estende CustomRequest, cujo failedValidation() sempre responde com esta mesma mensagem, independentemente do endpoint.',
+    properties: [
+        new OAT\Property(property: 'code', type: 'integer', example: 422),
+        new OAT\Property(property: 'message', type: 'string', example: 'Data validation errors'),
+        new OAT\Property(
+            property: 'data',
+            type: 'object',
+            properties: [
+                new OAT\Property(
+                    property: 'errors',
+                    type: 'object',
+                    additionalProperties: new OAT\AdditionalProperties(
+                        type: 'array',
+                        items: new OAT\Items(type: 'string')
+                    ),
+                    example: ['email' => ['The email field is required.']]
+                ),
+            ]
+        ),
+    ]
+)]
+#[OAT\Schema(
+    schema: 'UnauthenticatedResponse',
+    description: 'Resposta padrão do middleware auth:sanctum quando nenhum token válido é enviado. Não segue o envelope {code,message,data} do restante da API, pois é gerada pelo próprio framework antes de chegar ao controller.',
+    properties: [
+        new OAT\Property(property: 'message', type: 'string', example: 'Unauthenticated.'),
+    ]
+)]
 abstract class Controller
 {
     //

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "darkaonline/l5-swagger": "^11.1",
         "kreait/firebase-php": "*",
         "laravel/framework": "^13.8",
         "laravel/horizon": "^5.47",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3619e4abc404802e758d8ca87669c3e8",
+    "content-hash": "311f82b85d4c9b86e81f999870fe6909",
     "packages": [
         {
             "name": "beste/clock",
@@ -405,6 +405,86 @@
                 }
             ],
             "time": "2026-06-28T21:53:40+00:00"
+        },
+        {
+            "name": "darkaonline/l5-swagger",
+            "version": "11.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "110b59478c9417c13794cef62a82b019433d642a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/110b59478c9417c13794cef62a82b019433d642a",
+                "reference": "110b59478c9417c13794cef62a82b019433d642a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^13.0 || ^12.1 || ^11.44",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "zircote/swagger-php": "^6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^11.0 || ^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/11.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-12T10:04:41+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4311,6 +4391,53 @@
             "time": "2026-06-14T23:24:10+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -4851,6 +4978,68 @@
             "time": "2026-06-29T15:41:09+00:00"
         },
         {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -5111,6 +5300,67 @@
                 }
             ],
             "time": "2026-05-07T15:30:40+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.32.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/08bb057df45fa778351ccea63dfedf848d5c5edf",
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.9"
+            },
+            "time": "2026-07-17T08:23:23+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7507,6 +7757,88 @@
             "time": "2026-06-05T06:23:12+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v8.1.0",
             "source": {
@@ -7670,6 +8002,82 @@
                 }
             ],
             "time": "2026-06-09T10:54:51+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7947,6 +8355,95 @@
                 }
             ],
             "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/d2006242dae81ae8833ad9a0ffb74e3254654cff",
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/console": "^7.4 || ^8.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5 || >=12.5.22",
+                "rector/rector": "^2.3.1"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-12T03:44:54+00:00"
         }
     ],
     "packages-dev": [
@@ -9894,53 +10391,6 @@
             "time": "2026-01-06T21:53:42+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
-            },
-            "time": "2026-07-08T07:01:06+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
             "version": "12.5.7",
             "source": {
@@ -11514,12 +11964,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/backend/config/l5-swagger.php
+++ b/backend/config/l5-swagger.php
@@ -1,0 +1,337 @@
+<?php
+
+use L5Swagger\CustomGeneratorInterface;
+use L5Swagger\Generator;
+use OpenApi\scan;
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Optional CustomGeneratorInterface implementation that creates an OpenApi\Generator instance.
+             * Use this to provide a custom pre-configured generator.
+             * Accepts an instance or a class name (FQCN) implementing the interface.
+             *
+             * @see CustomGeneratorInterface
+             */
+            'generator_factory' => null,
+
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom processors.
+             *
+             * Each entry can be:
+             * - A class name or instance (inserted after BuildPaths by default)
+             * - An array with 'class' and 'after' keys for precise positioning:
+             *   ['class' => MyProcessor::class, 'after' => SomeProcessor::class]
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see scan
+             */
+            'processors' => [
+                // \App\SwaggerProcessors\SchemaQueryParameter::class,
+                // ['class' => \App\SwaggerProcessors\Custom::class, 'after' => \OpenApi\Processors\AugmentSchemas::class],
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -11,6 +11,9 @@ sleep 5
 echo "📦 Rodando migrations..."
 php artisan migrate --force
 
+echo "📄 Gerando documentação da API (Swagger)..."
+php artisan l5-swagger:generate
+
 echo "🧹 Limpando cache..."
 php artisan optimize:clear
 

--- a/backend/resources/views/vendor/l5-swagger/index.blade.php
+++ b/backend/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $documentationTitle }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        const urls = [];
+
+        @foreach($urlsToDocs as $title => $url)
+            urls.push({name: "{{ $title }}", url: "{{ $url }}"});
+        @endforeach
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            urls: urls,
+            "urls.primaryName": "{{ $documentationTitle }}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## docs(backend): documenta endpoints da API com Swagger (l5-swagger)

**Você usou IA para vibe-codar?**
Sim, utilizei e revisei.

**Você usou IA como fonte de pesquisa?**
Sim, pra investigar um bug de compatibilidade entre `zircote/swagger-php` e a versão do `phpstan/phpdoc-parser` do lock atual, e pra decidir a melhor prática de anotação em PHP 8 (ver "Achados extras" abaixo).

**Você REVISOU seu código antes de pedir por uma review?**
Sim.

**Você testou localmente?**
Sim, com PHP 8.4 (a versão que o próprio `composer.lock` do repo já exige — ver "Achado extra 4"). Passos:

1. `composer install` limpo + `npm ci && npm run build` (assets do Vite, necessários pros testes do backend).
2. Os três jobs do `backend-ci.yml`, replicados localmente de forma fiel ao pipeline (env fresco a partir do `.env.example`, SQLite do zero):
   - **`test`**: `php artisan test` → 35 testes, 81 assertions, 100% passando.
   - **`lint`** (Pint `--test`): passou. Precisei rodar `vendor/bin/pint` uma vez no `config/l5-swagger.php` (publicado automaticamente pelo pacote via `vendor:publish`), que veio com imports não totalmente qualificados e não seguia o estilo do resto do projeto.
   - **`docs`** (job novo, ver abaixo): `php artisan l5-swagger:generate` + `npx @redocly/cli lint storage/api-docs/api-docs.json` → válido.
3. Testes de contrato ao vivo: subi `php artisan serve` local e chamei os 13 endpoints documentados de verdade, comparando a resposta real com o schema documentado em cada um — não só o "sucesso feliz", mas também os caminhos de erro (401/404/422/500). Isso pegou pelo menos 3 divergências reais entre o que eu tinha documentado de cabeça e o que a API de fato retorna (detalhado nos achados extras).
4. Fluxo completo testado: `register` → `login` → `client/user` autenticado → `logout` → `forgot-password` → `verify-otp` (OTP lido direto do SQLite) → `reset-password` → login com senha nova → `client/user/update` (multipart, sem arquivo) → `client/resumes/new-resume` (multipart, com upload de arquivo PDF de verdade >5KB, respeitando a regra `min:5` em kilobytes) → `client/resumes/files` (achando o arquivo recém-enviado) → `client/resumes/pendings` → `client/resumes/pendings/{id}` (404 com id inexistente) → `client/user/resumes`.

### O que foi feito

Closes #134. Adiciona documentação Swagger/OpenAPI pros endpoints da API usando `darkaonline/l5-swagger ^11.1` (wrapper do `zircote/swagger-php`).

**Endpoints documentados (13, em 4 controllers):**

| Controller | Endpoint |
|---|---|
| `AuthController` | `POST /auth/login`, `POST /auth/register`, `POST /auth/logout`, `POST /auth/forgot-password`, `POST /auth/verify-otp`, `POST /auth/reset-password`, `GET /client/user` |
| `UserController` | `PUT /client/user/update` (multipart, incluindo os arrays aninhados de skills/experiences/qualifications/languages/projects) |
| `UserResumeController` | `GET /client/user/resumes` |
| `ResumeController` | `POST /client/resumes/new-resume` (multipart), `GET /client/resumes/files`, `GET /client/resumes/pendings`, `GET /client/resumes/pendings/{resume}` |

Cada endpoint documenta: request body (com os campos e tipos reais de cada `FormRequest`), resposta de sucesso, e respostas de erro específicas (401/400/404/422/500) — todas com o corpo real da resposta, não só a descrição textual.

**Schemas reutilizáveis:** adicionei `ValidationErrorResponse` e `UnauthenticatedResponse` em `Controller.php`, referenciados via `$ref` nos 7 e 8 endpoints respectivamente que os usam. Isso porque:
- Todo `FormRequest` da API estende `CustomRequest`, cujo `failedValidation()` sempre responde com a mesma mensagem fixa `"Data validation errors"` (`app/Http/ApiRequests/CustomRequest.php:21`), independente do endpoint — documentar isso por endpoint seria repetição.
- Toda rota com `auth:sanctum` retorna o mesmo `{"message":"Unauthenticated."}` do próprio Sanctum quando falta o token, sem o envelope `{code,message,data}` do resto da API.

**Infraestrutura:**
- `entrypoint.sh`: adiciona `php artisan l5-swagger:generate` antes do `optimize:clear`, do mesmo jeito que já roda `migrate`. Decisão consciente: a spec gerada (`storage/api-docs/`) **não** é versionada (adicionei ao `.gitignore`) — é tratada como artefato derivado do código, igual a um build, pra não divergir silenciosamente se alguém alterar um controller e esquecer de regenerar.
- Novo job de CI **`API docs (OpenAPI lint)`** em `backend-ci.yml`: gera a spec e roda `npx @redocly/cli lint` nela a cada push/PR que toque `backend/**`. Falha o CI se um endpoint futuro ficar sem `security` definido, com referência quebrada, ou com JSON inválido — é a mesma checagem que rodei manualmente e que pegou os itens do "Achado extra 2" abaixo.
- `CONTRIBUTING.md` (EN + PT): adiciona o passo de gerar/lintar a doc antes de commitar quando um endpoint de `backend/app/Http/Controllers/Api/**` for alterado, com comando via Docker pra quem não tem PHP/Node instalado (mesmo padrão já usado pro Pint e pro `dart format`).

**Decisões de escopo (fora deste PR):**
- `UserSkillController` não foi anotado — é um placeholder vazio (`// Implements on future`), sem nenhum método implementado.
- `POST /client/services/rabbitmq/process` (`ProducerResumesService`) não foi anotado — a rota e a classe ainda existem no código, mas o commit mais recente (`ba00e7a`, "remove RabbitMQ") sugere que a feature está em processo de remoção. Preferi não documentar algo que pode sumir no próximo PR.

Sem mudança de comportamento da aplicação — só atributos adicionados nos controllers. Conferi arquivo por arquivo antes de commitar: **zero linhas de lógica removidas ou alteradas** em qualquer controller (só `use OpenApi\Attributes as OAT;` + os blocos `#[OAT\...]` antes de cada método).

### Achado extra 1: bug de compatibilidade no `swagger-php`

A sintaxe clássica de docblock (`@OA\Info(...)` dentro de `/** */`) do `zircote/swagger-php` 6.4.0 falha **silenciosamente** neste projeto — `php artisan l5-swagger:generate` roda sem erro, mas a anotação simplesmente não é reconhecida (`Required @OA\Info() not found`), mesmo em arquivos isolados de teste. Reproduzi com um `StaticAnalyser`/CLI mínimo fora do projeto pra confirmar que não era erro de configuração nossa. A causa provável é uma incompatibilidade entre o parser de docblock do pacote e a versão do `phpstan/phpdoc-parser` (2.3.3) que o `composer.lock` resolve. A solução foi usar a sintaxe de **Atributos nativos do PHP 8** (`#[OpenApi\Attributes\...]`), que é o padrão atualmente recomendado pelo próprio pacote pra PHP 8+ e funciona sem problemas. Não bloqueou o PR, mas vale reportar upstream em algum momento.

### Achado extra 2: campo `code` ausente na primeira versão da doc

Ao testar contra o servidor real, percebi que toda resposta da API vem envelopada em `{code, message, data}` pelo helper `App\Helpers\ResponseData` (`ResponseData::handle()`) — inclusive o `code` no corpo, redundante com o HTTP status. Minha primeira versão da doc só tinha `message` e `data`. Corrigi as 13 respostas de sucesso e todas as respostas de erro documentadas pra incluir `code`, validando de novo contra chamadas reais depois da correção.

### Achado extra 3: inconsistência real no `ResumeController::storeNewResume`

Ao comparar a doc com o comportamento real, notei que `ResumeController::storeNewResume()` (linha ~119) captura `Exception` e responde com `data.errors` (string, a mensagem crua da exceção) — enquanto **todo o resto da API** usa `data.error` (singular, dentro de um objeto). Documentei essa inconsistência real como está no código (com uma nota explicando a diferença), em vez de "corrigir" silenciosamente a documentação pra parecer consistente. Pode valer um fix separado no código, fora do escopo deste PR — só sinalizando aqui pro caso de vocês quererem abrir uma issue.

### Achado extra 4: `composer.lock` já exigia PHP 8.4 antes deste PR

Não relacionado à documentação em si, mas registrando porque afetou o setup do ambiente: o `composer.json` declara `"php": "^8.3"`, mas o `composer.lock` **já commitado na `development`, antes de qualquer mudança minha** resolve `symfony/http-foundation v8.1.1`, que exige `php >=8.4.1`. Confirmei isso com `git show development:backend/composer.lock` antes de instalar qualquer coisa — não é uma versão que subi eu, é uma inconsistência pré-existente entre o `composer.json` e o `composer.lock` do projeto. Rodei tudo em PHP 8.4 (a versão que o lock de fato exige), sem tocar nessa constraint. Também não mexi nisso neste PR, por ser um assunto totalmente separado da documentação — mas fica o registro caso valha abrir uma issue à parte.
