### PR TITLE
chore(security): corrige vulnerabilidades apontadas pelo composer/npm audit

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -1523,22 +1523,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "aef242412e13128b5049864867bb49fc37dd39de"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aef242412e13128b5049864867bb49fc37dd39de",
-                "reference": "aef242412e13128b5049864867bb49fc37dd39de",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.12.4",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1551,7 +1551,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.3",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1631,7 +1631,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -1647,7 +1647,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T22:54:09+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1735,16 +1735,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.4",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
-                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -1834,7 +1834,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.4"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1850,7 +1850,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:56:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -11514,12 +11514,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4458,9 +4458,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## chore(security): corrige vulnerabilidades apontadas pelo composer/npm audit

**Você usou IA para vibe-codar?**
Sim, utilizei e revisei.

**Você usou IA como fonte de pesquisa?**
Sim, pra investigar as duas advisories e confirmar que eram dependências transitivas (não diretas) antes de decidir o bump.

**Você REVISOU seu código antes de pedir por uma review?**
Sim.

**Você testou localmente?**
Sim, com PHP 8.4. Além de rodar as checagens do CI, subi o projeto de verdade com as dependências atualizadas pra ter certeza de que nada quebrou em runtime, não só no lint/testes:

| Camada | Teste | Resultado |
|---|---|---|
| Backend | `composer install` limpo com o lock atualizado | ✅ |
| Backend | `composer audit` | ✅ limpo (0 advisories, era 1 antes) |
| Backend | Requisição HTTP real via `GuzzleHttp\Client` (`php artisan tinker`) | ✅ status 200 |
| Backend | `App\Services\Firebase\PushNotificationService` (consumidora do Guzzle via `kreait/firebase-php`) carrega sem erro | ✅ |
| Backend | `POST /auth/register` via `php artisan serve` real | ✅ 201, resposta correta |
| Backend | `vendor/bin/pint --test` | ✅ |
| Backend | `php artisan test` | ✅ 35 testes, 81 assertions |
| Frontend | `npm audit --audit-level=high` | ✅ limpo (0 vulnerabilidades, era 1 antes) |
| Frontend | `npm run dev` sobe sem erro, página carrega (HTTP 200) | ✅ |
| Frontend | `npm run lint` (usa `eslint` → `minimatch` → `brace-expansion`, a dependência atualizada) | ✅ |
| Frontend | `npm run build` (`tsc -b && vite build`) | ✅ |

`brace-expansion` é dependência só de lint/build, nunca vai pro bundle de produção — o `npm run lint` já exercita o código que a atualiza na prática.

### O que foi feito:

Corrige as 2 falhas do workflow `security-audit.yml` que apareceram no PR #146 (documentação Swagger), sem relação com aquele PR — são vulnerabilidades pré-existentes na `development`, reportadas no dia 20/07/2026.

1. **`guzzlehttp/guzzle`**: `7.14.0` → `7.15.1` (dependência transitiva, via `laravel/framework`, `kreait/firebase-php`, `google/auth`, `google/cloud-core` — nenhum requer diretamente no `composer.json`). Corrige [GHSA-94pj-82f3-465w](https://github.com/advisories/GHSA-94pj-82f3-465w) (severidade média): headers `Proxy-Authorization` podiam vazar pro servidor de origem em certos redirects. `guzzlehttp/psr7` subiu junto (`2.12.4` → `2.13.0`), porque o próprio Guzzle passou a exigir `^2.13` dele — não mexi nele diretamente.
2. **`brace-expansion`**: `5.0.6` → `5.0.7` (dependência transitiva de `eslint` → `minimatch`, só usada em lint/dev, não vai pro bundle de produção), via `npm audit fix` (sem `--force`). Corrige [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (severidade alta): DoS por expansão exponencial de grupos `{}` consecutivos não-expansíveis.

Nenhuma constraint em `composer.json`/`package.json` foi alterada — só os lockfiles, com o menor bump possível em cada caso (patch/minor dentro da mesma major, respeitando as constraints já declaradas pelos pacotes que dependem deles).

### Achado extra: ruído cosmético no `composer.lock`

O diff do `composer.lock` também mudou os campos `stability-flags`, `platform-dev` (de `{}` pra `[]`) e `plugin-api-version` (`2.9.0` → `2.6.0`). Isso é só porque o Composer instalado aqui (`2.7.1`, via `apt`, sem suporte a `self-update`) é mais antigo que o que gerou o lock anteriormente — não afeta o `composer install` do CI, que só consome o lock como está. Deixei como está por ser puramente cosmético; a próxima pessoa com um Composer mais novo que tocar no lock deve normalizar de novo naturalmente.
