### PR TITLE
Feat/backend swagger docs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+L5_SWAGGER_CONST_HOST=http://localhost:8000/api
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -19,6 +19,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/api-docs
 /storage/pail
 /vendor
 _ide_helper.php

--- a/backend/app/Http/Controllers/Api/Auth/AuthController.php
+++ b/backend/app/Http/Controllers/Api/Auth/AuthController.php
@@ -18,9 +18,46 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Auth', description: 'Autenticação e recuperação de senha')]
 class AuthController extends Controller
 {
+    #[OA\Post(
+        path: '/auth/login',
+        tags: ['Auth'],
+        summary: 'Login do usuário',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['email', 'password'],
+                properties: [
+                    new OA\Property(property: 'email', type: 'string', format: 'email', example: 'user@example.com'),
+                    new OA\Property(property: 'password', type: 'string', format: 'password', example: 'senha123'),
+                    new OA\Property(property: 'fcm', type: 'string', nullable: true, description: 'Token de push notification do dispositivo'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Login realizado com sucesso',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'token', type: 'string'),
+                                new OA\Property(property: 'user', type: 'object'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Credenciais inválidas', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+            new OA\Response(response: 422, description: 'Erro de validação', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function login(LoginRequest $request)
     {
         try {
@@ -54,6 +91,42 @@ class AuthController extends Controller
         }
     }
 
+    #[OA\Post(
+        path: '/auth/register',
+        tags: ['Auth'],
+        summary: 'Cria uma nova conta',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'email', 'password', 'password_confirm'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Pedro Aruanã'),
+                    new OA\Property(property: 'email', type: 'string', format: 'email'),
+                    new OA\Property(property: 'password', type: 'string', format: 'password'),
+                    new OA\Property(property: 'password_confirm', type: 'string', format: 'password'),
+                    new OA\Property(property: 'fcm', type: 'string', nullable: true),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Usuário criado',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'token', type: 'string'),
+                                new OA\Property(property: 'user', type: 'object'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 422, description: 'Erro de validação (ex: email já cadastrado)', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function register(RegisterRequest $request)
     {
 
@@ -87,6 +160,16 @@ class AuthController extends Controller
 
     }
 
+    #[OA\Post(
+        path: '/auth/logout',
+        tags: ['Auth'],
+        summary: 'Encerra a sessão atual (revoga o token)',
+        security: [['sanctum' => []]],
+        responses: [
+            new OA\Response(response: 200, description: 'Logout realizado', content: new OA\JsonContent(ref: '#/components/schemas/ApiSuccessResponse')),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function logout(Request $request)
     {
         $request->user()->currentAccessToken()->delete();
@@ -98,6 +181,37 @@ class AuthController extends Controller
         return ResponseData::success('Logged out successfully');
     }
 
+    #[OA\Post(
+        path: '/auth/forgot-password',
+        tags: ['Auth'],
+        summary: 'Envia um código OTP por email pra iniciar a recuperação de senha',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['email'],
+                properties: [
+                    new OA\Property(property: 'email', type: 'string', format: 'email', description: 'Precisa ser um email já cadastrado'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'OTP enviado',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'expires_at', type: 'string', format: 'date-time'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 422, description: 'Email não encontrado', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function forgotPassword(ForgotPasswordRequest $request)
     {
         try {
@@ -131,6 +245,38 @@ class AuthController extends Controller
         }
     }
 
+    #[OA\Post(
+        path: '/auth/verify-otp',
+        tags: ['Auth'],
+        summary: 'Verifica o código OTP enviado por email',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['otp'],
+                properties: [
+                    new OA\Property(property: 'otp', type: 'string', example: '123456', description: 'Código de 6 dígitos'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'OTP válido',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'message', type: 'string'),
+                                new OA\Property(property: 'user_id', type: 'integer'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, description: 'OTP inválido ou expirado', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function verifyOtp(VerifyOtpRequest $request)
     {
         try {
@@ -160,6 +306,26 @@ class AuthController extends Controller
         }
     }
 
+    #[OA\Post(
+        path: '/auth/reset-password',
+        tags: ['Auth'],
+        summary: 'Define a nova senha após validar o OTP',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['otp', 'password', 'password_confirm'],
+                properties: [
+                    new OA\Property(property: 'otp', type: 'string', example: '123456'),
+                    new OA\Property(property: 'password', type: 'string', format: 'password'),
+                    new OA\Property(property: 'password_confirm', type: 'string', format: 'password'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Senha alterada com sucesso', content: new OA\JsonContent(ref: '#/components/schemas/ApiSuccessResponse')),
+            new OA\Response(response: 422, description: 'OTP inválido/expirado ou senhas não conferem', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function resetPassword(ResetPasswordRequest $request)
     {
 
@@ -187,6 +353,29 @@ class AuthController extends Controller
 
     }
 
+    #[OA\Get(
+        path: '/client/user',
+        tags: ['Auth'],
+        summary: 'Retorna os dados do usuário autenticado, com relações completas',
+        security: [['sanctum' => []]],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Usuário retornado com skills, experiences, qualifications, languages e projects',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'user', type: 'object'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function user(Request $request)
     {
         return ResponseData::success('User retrieved successfully', [

--- a/backend/app/Http/Controllers/Api/Resume/ResumeController.php
+++ b/backend/app/Http/Controllers/Api/Resume/ResumeController.php
@@ -13,11 +13,44 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Resume', description: 'Upload, listagem e status dos currículos')]
 class ResumeController extends Controller
 {
     use UserProcessRelationsTrait, UserUploadsTrait;
 
+    #[OA\Post(
+        path: '/client/resumes/new-resume',
+        tags: ['Resume'],
+        summary: 'Envia um novo currículo (CV e/ou LinkedIn) pra análise da IA',
+        security: [['sanctum' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
+                        new OA\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
+                        new OA\Property(property: 'github_link', type: 'string', nullable: true),
+                        new OA\Property(property: 'site_link', type: 'string', nullable: true),
+                        new OA\Property(
+                            property: 'skills', type: 'array', nullable: true,
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'name', type: 'string'),
+                            ])
+                        ),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Upload processado', content: new OA\JsonContent(ref: '#/components/schemas/ApiSuccessResponse')),
+            new OA\Response(response: 422, description: 'Erro de validação', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function storeNewResume(NewResumeRequest $request)
     {
 
@@ -67,6 +100,36 @@ class ResumeController extends Controller
         }
     }
 
+    #[OA\Get(
+        path: '/client/resumes/files',
+        tags: ['Resume'],
+        summary: 'Gera um link temporário (24h) pra baixar um arquivo do usuário',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(
+                name: 'type', in: 'query', required: false,
+                description: 'Qual arquivo buscar. Padrão: cv',
+                schema: new OA\Schema(type: 'string', enum: ['cv', 'linkedin', 'pcd'], default: 'cv')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'URL temporária gerada',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'file_url', type: 'string'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 404, description: 'Arquivo não encontrado', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function getResumesFiles(Request $request)
     {
         $user = $request->user();
@@ -93,6 +156,27 @@ class ResumeController extends Controller
 
     }
 
+    #[OA\Get(
+        path: '/client/resumes/pendings',
+        tags: ['Resume'],
+        summary: 'Lista as análises de currículo do usuário (histórico/status de processamento)',
+        security: [['sanctum' => []]],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Lista de análises',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'array', items: new OA\Items(type: 'object')),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function resumeAnalytics(Request $request)
     {
         return ResponseData::success(
@@ -102,6 +186,23 @@ class ResumeController extends Controller
         );
     }
 
+    #[OA\Get(
+        path: '/client/resumes/pendings/{resume}',
+        tags: ['Resume'],
+        summary: 'Detalha uma análise de currículo específica do usuário',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(
+                name: 'resume', in: 'path', required: true,
+                description: 'ID do registro de análise (ResumeAnalytic)',
+                schema: new OA\Schema(type: 'integer')
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Análise encontrada', content: new OA\JsonContent(ref: '#/components/schemas/ApiSuccessResponse')),
+            new OA\Response(response: 404, description: 'Não encontrada ou não pertence ao usuário', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function showPendingResume(Request $request, int $resume)
     {
 

--- a/backend/app/Http/Controllers/Api/User/UserController.php
+++ b/backend/app/Http/Controllers/Api/User/UserController.php
@@ -10,11 +10,113 @@ use App\Http\Controllers\Controller;
 use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'User', description: 'Perfil e dados do usuário autenticado')]
 class UserController extends Controller
 {
     use UserProcessRelationsTrait, UserUploadsTrait;
 
+    #[OA\Put(
+        path: '/client/user/update',
+        tags: ['User'],
+        summary: 'Atualiza o perfil do usuário (dados pessoais, arquivos e listas de skills/experiências/qualificações/idiomas/projetos)',
+        description: 'multipart/form-data por causa dos uploads (resume_cv, resume_linkedin, path_certificate_pcd). Listas enviadas (skills, experiences, etc.) substituem as anteriores.',
+        security: [['sanctum' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'name', type: 'string'),
+                        new OA\Property(property: 'password', type: 'string', format: 'password'),
+                        new OA\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
+                        new OA\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
+                        new OA\Property(property: 'path_certificate_pcd', type: 'string', format: 'binary'),
+                        new OA\Property(property: 'github_link', type: 'string', nullable: true),
+                        new OA\Property(property: 'site_link', type: 'string', nullable: true),
+                        new OA\Property(property: 'linkedin_link', type: 'string', nullable: true),
+                        new OA\Property(property: 'social_name', type: 'string', nullable: true),
+                        new OA\Property(property: 'phone', type: 'string', nullable: true),
+                        new OA\Property(property: 'resume_email', type: 'string', format: 'email', nullable: true),
+                        new OA\Property(property: 'gender', type: 'string', nullable: true),
+                        new OA\Property(property: 'is_pcd', type: 'boolean', nullable: true),
+                        new OA\Property(property: 'city', type: 'string', nullable: true),
+                        new OA\Property(property: 'state', type: 'string', nullable: true),
+                        new OA\Property(property: 'country', type: 'string', nullable: true),
+                        new OA\Property(
+                            property: 'skills', type: 'array',
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'name', type: 'string'),
+                                new OA\Property(property: 'years', type: 'string', nullable: true),
+                            ])
+                        ),
+                        new OA\Property(
+                            property: 'experiences', type: 'array',
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'company', type: 'string'),
+                                new OA\Property(property: 'role', type: 'string'),
+                                new OA\Property(property: 'start', type: 'string', format: 'date'),
+                                new OA\Property(property: 'end', type: 'string', format: 'date', nullable: true),
+                                new OA\Property(property: 'description', type: 'string', nullable: true),
+                                new OA\Property(property: 'is_actual', type: 'boolean'),
+                                new OA\Property(property: 'city', type: 'string', nullable: true),
+                                new OA\Property(property: 'state', type: 'string', nullable: true),
+                                new OA\Property(property: 'country', type: 'string', nullable: true),
+                            ])
+                        ),
+                        new OA\Property(
+                            property: 'qualifications', type: 'array',
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'type', type: 'string', description: 'elementary_education | high_school | extracurricular_course | technical_course | undergraduate_degree | postgraduate_degree | master_degree | doctorate_degree'),
+                                new OA\Property(property: 'institution', type: 'string'),
+                                new OA\Property(property: 'title', type: 'string'),
+                                new OA\Property(property: 'start', type: 'string', format: 'date'),
+                                new OA\Property(property: 'end', type: 'string', format: 'date', nullable: true),
+                                new OA\Property(property: 'is_coursing', type: 'boolean'),
+                            ])
+                        ),
+                        new OA\Property(
+                            property: 'languages', type: 'array',
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'level', type: 'string', description: 'beginner | intermediate | advanced | fluent | native'),
+                                new OA\Property(property: 'language', type: 'string'),
+                            ])
+                        ),
+                        new OA\Property(
+                            property: 'projects', type: 'array',
+                            items: new OA\Items(properties: [
+                                new OA\Property(property: 'title', type: 'string'),
+                                new OA\Property(property: 'date', type: 'string', description: 'ano, 4 dígitos'),
+                                new OA\Property(property: 'technologies', type: 'string'),
+                                new OA\Property(property: 'description', type: 'string'),
+                                new OA\Property(property: 'url', type: 'string'),
+                            ])
+                        ),
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Perfil atualizado',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'user', type: 'object'),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 422, description: 'Erro de validação', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function update(UpdateUserRequest $request)
     {
 

--- a/backend/app/Http/Controllers/Api/User/UserResumeController.php
+++ b/backend/app/Http/Controllers/Api/User/UserResumeController.php
@@ -7,9 +7,33 @@ use App\Http\Controllers\Controller;
 use App\Models\UserResume;
 use Exception;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
 class UserResumeController extends Controller
 {
+    #[OA\Get(
+        path: '/client/user/resumes',
+        tags: ['User'],
+        summary: 'Lista os currículos gerados pelo usuário, do mais recente pro mais antigo',
+        security: [['sanctum' => []]],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Lista de currículos',
+                content: new OA\JsonContent(
+                    allOf: [
+                        new OA\Schema(ref: '#/components/schemas/ApiSuccessResponse'),
+                        new OA\Schema(properties: [
+                            new OA\Property(property: 'data', type: 'object', properties: [
+                                new OA\Property(property: 'data', type: 'array', items: new OA\Items(type: 'object')),
+                            ]),
+                        ]),
+                    ]
+                )
+            ),
+            new OA\Response(response: 401, description: 'Não autenticado'),
+        ]
+    )]
     public function __invoke(Request $request)
     {
         try {

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -2,6 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use OpenApi\Attributes as OA;
+
+#[OA\Info(
+    title: 'Bom Currículo API',
+    version: '1.0.0',
+    description: 'API do Bom Currículo: autenticação, dados do usuário e geração de currículo.'
+)]
+#[OA\Server(
+    url: L5_SWAGGER_CONST_HOST,
+    description: 'Servidor da API'
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'sanctum',
+    type: 'http',
+    scheme: 'bearer',
+    description: "Token obtido em /auth/login ou /auth/register. Envie como 'Bearer {token}'."
+)]
 abstract class Controller
 {
     //

--- a/backend/app/OpenApi/Schemas/ApiErrorResponse.php
+++ b/backend/app/OpenApi/Schemas/ApiErrorResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ApiErrorResponse',
+    properties: [
+        new OA\Property(property: 'code', type: 'integer', example: 422),
+        new OA\Property(property: 'message', type: 'string', example: 'Validation failed'),
+        new OA\Property(
+            property: 'data',
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'errors', type: 'object'),
+            ]
+        ),
+    ]
+)]
+class ApiErrorResponse
+{
+    //
+}

--- a/backend/app/OpenApi/Schemas/ApiSuccessResponse.php
+++ b/backend/app/OpenApi/Schemas/ApiSuccessResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ApiSuccessResponse',
+    properties: [
+        new OA\Property(property: 'code', type: 'integer', example: 200),
+        new OA\Property(property: 'message', type: 'string', example: 'Request successful'),
+        new OA\Property(property: 'data', type: 'object'),
+    ]
+)]
+class ApiSuccessResponse
+{
+    //
+}

--- a/backend/app/Services/RabbitMQ/Resume/ProducerResumesService.php
+++ b/backend/app/Services/RabbitMQ/Resume/ProducerResumesService.php
@@ -7,9 +7,28 @@ use App\Jobs\Api\RabbitMQ\Resumes\ResumeProcessingPublisher;
 use App\Models\UserResume;
 use Exception;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Resume', description: 'Upload, listagem e status dos currículos')]
 class ProducerResumesService
 {
+    #[OA\Post(
+        path: '/client/services/rabbitmq/process',
+        tags: ['Resume'],
+        summary: 'Dispara o processamento de um currículo do usuário na fila (RabbitMQ)',
+        security: [['sanctum' => []]],
+        requestBody: new OA\RequestBody(
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'user_resume_id', type: 'integer', nullable: true, description: 'ID do currículo a processar; se omitido, usa o mais recente'),
+                ]
+            )
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Enviado pra fila com sucesso', content: new OA\JsonContent(ref: '#/components/schemas/ApiSuccessResponse')),
+            new OA\Response(response: 404, description: 'Currículo não encontrado pra esse usuário', content: new OA\JsonContent(ref: '#/components/schemas/ApiErrorResponse')),
+        ]
+    )]
     public function __invoke(Request $request)
     {
         try {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "darkaonline/l5-swagger": "^11.1",
         "kreait/firebase-php": "*",
         "laravel/framework": "^13.8",
         "laravel/horizon": "^5.47",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3619e4abc404802e758d8ca87669c3e8",
+    "content-hash": "311f82b85d4c9b86e81f999870fe6909",
     "packages": [
         {
             "name": "beste/clock",
@@ -405,6 +405,86 @@
                 }
             ],
             "time": "2026-06-28T21:53:40+00:00"
+        },
+        {
+            "name": "darkaonline/l5-swagger",
+            "version": "11.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "110b59478c9417c13794cef62a82b019433d642a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/110b59478c9417c13794cef62a82b019433d642a",
+                "reference": "110b59478c9417c13794cef62a82b019433d642a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^13.0 || ^12.1 || ^11.44",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "zircote/swagger-php": "^6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^11.0 || ^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/11.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-12T10:04:41+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -4311,6 +4391,53 @@
             "time": "2026-06-14T23:24:10+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -4851,6 +4978,68 @@
             "time": "2026-06-29T15:41:09+00:00"
         },
         {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -5111,6 +5300,67 @@
                 }
             ],
             "time": "2026-05-07T15:30:40+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.32.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/08bb057df45fa778351ccea63dfedf848d5c5edf",
+                "reference": "08bb057df45fa778351ccea63dfedf848d5c5edf",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.9"
+            },
+            "time": "2026-07-17T08:23:23+00:00"
         },
         {
             "name": "symfony/clock",
@@ -7507,6 +7757,88 @@
             "time": "2026-06-05T06:23:12+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v8.1.0",
             "source": {
@@ -7670,6 +8002,82 @@
                 }
             ],
             "time": "2026-06-09T10:54:51+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7947,6 +8355,95 @@
                 }
             ],
             "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/d2006242dae81ae8833ad9a0ffb74e3254654cff",
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/console": "^7.4 || ^8.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5 || >=12.5.22",
+                "rector/rector": "^2.3.1"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-12T03:44:54+00:00"
         }
     ],
     "packages-dev": [
@@ -9892,53 +10389,6 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
             "time": "2026-01-06T21:53:42+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
-            },
-            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/backend/config/l5-swagger.php
+++ b/backend/config/l5-swagger.php
@@ -1,0 +1,337 @@
+<?php
+
+use L5Swagger\CustomGeneratorInterface;
+use L5Swagger\Generator;
+use OpenApi\scan;
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Optional CustomGeneratorInterface implementation that creates an OpenApi\Generator instance.
+             * Use this to provide a custom pre-configured generator.
+             * Accepts an instance or a class name (FQCN) implementing the interface.
+             *
+             * @see CustomGeneratorInterface
+             */
+            'generator_factory' => null,
+
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom processors.
+             *
+             * Each entry can be:
+             * - A class name or instance (inserted after BuildPaths by default)
+             * - An array with 'class' and 'after' keys for precise positioning:
+             *   ['class' => MyProcessor::class, 'after' => SomeProcessor::class]
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see scan
+             */
+            'processors' => [
+                // \App\SwaggerProcessors\SchemaQueryParameter::class,
+                // ['class' => \App\SwaggerProcessors\Custom::class, 'after' => \OpenApi\Processors\AugmentSchemas::class],
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/backend/resources/views/vendor/l5-swagger/index.blade.php
+++ b/backend/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $documentationTitle }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        const urls = [];
+
+        @foreach($urlsToDocs as $title => $url)
+            urls.push({name: "{{ $title }}", url: "{{ $url }}"});
+        @endforeach
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            urls: urls,
+            "urls.primaryName": "{{ $documentationTitle }}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Descrição

Resolve a issue #134
- instalei o darkaonline/l5-swagger (compatível com Laravel 13)
- documentei os 14 endpoints reais da api: auth (login, registro, logout, 
  recuperação de senha), perfil do usuário e currículos
- cada endpoint com parâmetros, corpo da requisição e todas as respostas possíveis
- criei schemas reutilizáveis pro formato padrão de resposta do projeto (sucesso/erro)
obs: as anotações usam o formato moderno de PHP Attributes, não o docblock 
clássico, que está depreciado nessa versão do swagger-php

## Uso de IA

- [x] Vibe-code
- [ ] Pesquisa

## Tipo de mudança

- [ ] Bug fix
- [x] Nova feature
- [ ] Breaking change
- [ ] Documentação
- [ ] Chore / infra

## Área afetada

- [ ] frontend
- [x] backend
- [ ] mobile
- [ ] bot
- [ ] CI/CD

## Checklist

- [x] Testei localmente
- [ ] Adicionei/atualizei testes quando necessário
- [x] `npm run lint` / `vendor/bin/pint` / `flutter analyze` passando
- [ ] Atualizei a documentação quando necessário

## Como testar

<!-- Passo a passo pra quem for revisar -->

1. entra na pasta backend
2. roda composer install
3. roda php artisan l5-swagger:generate
4. roda php artisan serve
5. abre http://127.0.0.1:8000/api/documentation no navegador
6. deve mostrar a tela do swagger com os 14 endpoints organizados em Auth/Resume/User

<img width="1769" height="870" alt="Captura de tela 2026-07-20 220719" src="https://github.com/user-attachments/assets/993eb634-2dc4-4b78-8796-fc986a66dc5c" />
