### PR TITLE
test(backend): add login and FCM device tests

### DIFF
--- a/backend/tests/Feature/Auth/LoginTest.php
+++ b/backend/tests/Feature/Auth/LoginTest.php
@@ -1,4 +1,9 @@
 <?php
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+
+uses(RefreshDatabase::class);
 
 it('can login successfully', function () {
 
@@ -13,11 +18,164 @@ it('can login successfully', function () {
 
     $response->assertOk()
         ->assertJsonStructure([
-            'code',
-            'message',
-            'data' => [
-                'token',
-                'user',
-            ],
+        'code',
+        'message',
+        'data' => [
+            'token',
+            'user',
+        ],
+    ]);
+});
+
+describe('invalid cretentials',function(){
+    it('returns status 401 when the password is incorrect', function () {
+        $user = authUser([
+            'email' => 'usuario@email.com',
+            'password' => Hash::make('senha-correta'),
         ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'usuario@email.com',
+            'password' => 'senha-incorreta',
+        ]);
+
+        $response
+            ->assertUnauthorized()
+            ->assertJson([
+                'message' => 'Invalid credentials',
+            ])
+        ->assertJsonMissingPath('token');
+
+        $this->assertDatabaseMissing('user_devices', [
+            'user_id' => $user->id,
+        ]);
+    });
+    it('returns status 401 when the email does not exist', function () {
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'lucas@gmail.com',
+            'password' => 'senha-incorreta',
+        ]);
+
+        $response
+            ->assertUnauthorized()
+            ->assertJson([
+                'message' => 'Invalid credentials',
+            ])
+        ->assertJsonMissingPath('token');
+
+    });
+    it('returns status 422 when email is missing', function () {
+        $response = $this->postJson('/api/auth/login', [
+            'password' => 'senha',
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure([
+                'code',
+                'message',
+                'data' => [
+                    'errors' => [
+                        'email',
+                    ],
+                ],
+            ]);
+    });
+
+    it('returns status 422 when password is missing', function () {
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'test@gmail.com',
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJsonStructure([
+                'code',
+                'message',
+                'data' => [
+                    'errors' => [
+                        'password',
+                    ],
+                ],
+            ]);
+    });
+});
+
+
+
+describe('FCM token',function(){
+    it('creates a device when the fcm token is new', function () {
+        $user = authUser([
+            'email' => 'usuario@email.com',
+            'password' => Hash::make('senha-correta'),
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'senha-correta',
+            'fcm'=>'token-fcm-123'
+        ]);
+
+        $response->assertJson([
+            'message' => 'Login successful',
+        ]);
+
+        $this->assertDatabaseHas('user_devices', [
+            'user_id' => $user->id,
+            'fcm_token' => 'token-fcm-123',
+        ]);
+    });
+    it('does not create a device when fcm is not provided', function () {
+        $user = authUser([
+            'email' => 'usuario@email.com',
+            'password' => Hash::make('senha-correta'),
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'senha-correta',
+        ]);
+
+        $response->assertJson([
+            'message' => 'Login successful',
+        ]);
+
+        $this->assertDatabaseMissing('user_devices', [
+            'user_id' => $user->id,
+            'fcm_token' => 'token-fcm-123',
+        ]);
+    });
+    it('does not duplicate an existing fcm token',function(){
+        $fcmToken = 'token-fcm-123';
+        $user = authUser([
+            'email' => 'usuario@email.com',
+            'password' => Hash::make('senha-correta'),
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'senha-correta',
+            'fcm'=>$fcmToken
+        ]);
+
+        $response->assertJson([
+            'message' => 'Login successful',
+        ]);
+        $response2 = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'senha-correta',
+            'fcm'=>$fcmToken
+        ]);
+
+        $response2->assertJson([
+            'message'=>'Login successful'
+        ]);
+
+        
+        expect(
+            $user->devices()->where('fcm_token',$fcmToken)
+            ->count()
+        )->toBe(1);
+    });
+
 });


### PR DESCRIPTION
## Descrição

<!-- O que esse PR faz e por quê -->

## Uso de IA

- [ ] Vibe-code
- [ x] Pesquisa

## Tipo de mudança

- [ ] Bug fix
- [ ] Nova feature
- [ ] Breaking change
- [ ] Documentação
- [ x] Chore / infra

## Área afetada

- [ ] frontend
- [x ] backend
- [ ] mobile
- [ ] bot
- [ ] CI/CD

## Checklist

- [x ] Testei localmente
- [ ] Adicionei/atualizei testes quando necessário
- [ ] `npm run lint` / `vendor/bin/pint` / `flutter analyze` passando
- [ ] Atualizei a documentação quando necessário

## Como testar

<!-- Passo a passo pra quem for revisar -->

Adicionei testes automatizados para a rota de login, cobrindo cenários de autenticação, validação dos campos obrigatórios e tratamento de credenciais inválidas.

Também foram adicionados testes para o fluxo de FCM, garantindo que o dispositivo seja criado quando o token é novo, não seja criado quando o token não é enviado e não seja duplicado quando já existe.
