### PR TITLE
chore(ci): dependabot passa a abrir PRs contra development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Frontend (npm)
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:
@@ -20,6 +21,7 @@ updates:
   # Backend - assets/vite (npm)
   - package-ecosystem: "npm"
     directory: "/backend"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:
@@ -32,6 +34,7 @@ updates:
   # Backend (composer / PHP)
   - package-ecosystem: "composer"
     directory: "/backend"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:
@@ -44,6 +47,7 @@ updates:
   # Mobile (pub / Dart-Flutter)
   - package-ecosystem: "pub"
     directory: "/mobile"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:
@@ -56,6 +60,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
## Contexto

A PR do dependabot #153 (bump `brace-expansion`) estava falhando no CI por motivos que não tinham nada a ver com o bump em si: ela é aberta contra `main`, que hoje está **45 commits atrás** da `development` e carrega seus próprios problemas de CI (lockfile desatualizado, vulnerabilidade high, code style).

Sem `target-branch` definido, o dependabot usa o branch padrão do repositório (`main`). Isso significa que toda PR de dependência nasce sujeita ao estado da `main`, que só é atualizada quando alguém promove `development` → `main` manualmente.

## Mudança

Define `target-branch: "development"` em todos os ecossistemas do `.github/dependabot.yml` (npm frontend, npm/composer backend, pub mobile, github-actions). A partir daí:

- PRs de dependência passam a nascer contra `development`, seguindo o mesmo fluxo do resto do desenvolvimento.
- CI pega quebras cedo (lint, testes, audit rodando no código atual), em vez de misturar problemas da `main` desatualizada com o bump em si.
- `main` continua recebendo essas atualizações indiretamente, quando `development` for promovida pra lá.

## Test plan

- [x] Validado a sintaxe do YAML (indentação/estrutura igual aos blocos existentes)
- Próxima geração de PRs do dependabot (próxima janela semanal, ou forçando via Insights > Dependency graph > Dependabot) deve abrir contra `development`