### PR TITLE
fix(frontend): corrige CVE-2026-13149 (brace-expansion) e fast-uri high na main

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3869,9 +3869,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4967,9 +4967,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7387,9 +7387,9 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.12.0.tgz",
-      "integrity": "sha512-o781ieQziCnXH2FKsEqxp1fnbHdbgAPO9inTSPeZ59hQfsZXuMGp3ul8oFSV5KQS4nbUK9b+DrDE6C7OvfKKQQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.14.0.tgz",
+      "integrity": "sha512-WSSMmB9ERauwy0SQwE0NlSfeaoBANHtzgSjAfoEsIHpRQwVkQBiiLV8Y9yAYOj9Wf3mbCIdQt3oLGzkH7NQFiQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",


### PR DESCRIPTION
## Contexto

O #153 (dependabot: bump brace-expansion 5.0.6 -> 5.0.7) corrigia o [CVE-2026-13149](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (DoS de alta severidade), mas ficou preso: o dependabot não reagenda a base de um PR já aberto (nem com `@dependabot rebase`/`recreate`, nem editando a base manualmente), então continuava rebaseando contra `main` mesmo depois do #156 mudar o `target-branch` pra `development`. Como a `main` estava desatualizada e com CI quebrado por lint pré-existente, os checks falhavam por motivos alheios ao bump e o PR acabou fechado sem merge.

Esse PR reaplica o fix manualmente direto na `main`.

## Mudanças
- `brace-expansion` 5.0.6 -> 5.0.7 (CVE-2026-13149, DoS, GHSA-3jxr-9vmj-r5cp)
- `fast-uri` 3.1.2 -> 3.1.4 (high, host confusion — GHSA-v2hh-gcrm-f6hx / GHSA-4c8g-83qw-93j6), via `npm audit fix`
- `shadcn` 4.12.0 -> 4.14.0 (bump transitivo trazido pelo audit fix acima)

Não toquei na vulnerabilidade moderate de `@hono/node-server` porque o fix exige `--force` e um breaking change no `shadcn`.

## Aviso

O CI desse PR **vai continuar falhando no lint** (`button.tsx`, `sidebar.tsx`, `use-mobile.ts`, `theme-provider.tsx`) — são os mesmos 4 erros pré-existentes na `main` que já foram corrigidos na `development` pelo #155. Esse PR não inclui esse fix pra manter o escopo só na correção de segurança; avisem se quiserem que eu traga o #155 pra `main` também.

## Test plan
- [x] `npm ci` instala limpo com o lockfile atualizado
- [x] `npm audit --audit-level=high` sem findings altos/críticos
- [ ] Lint da `main` (pré-existente, fora do escopo deste PR)