### PR TITLE
chore(ci): dependabot passa a abrir PRs de python (/bot) contra development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,19 @@ updates:
     commit-message:
       prefix: "chore(mobile)"
 
+  # Bot (uv / Python)
+  - package-ecosystem: "uv"
+    directory: "/bot"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    groups:
+      bot-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(bot)"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Adiciona a entrada do ecossistema `uv` (Python) do `/bot` no `dependabot.yml`, com `target-branch: development`, igual aos demais ecossistemas.

Faltava essa entrada, então os updates de dependências do bot (ex: PR #166, bump do `pyasn1`) abriam direto contra `main` em vez de `development`.

Closes #167