### PR TITLE
chore(ci): limpa baseline de lint e adiciona autofix de Pint/dart format

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,93 @@
+name: Autofix (Pint / dart format)
+
+# Roda com permissoes de escrita e sem segredos de fork: so aceita PRs do
+# proprio repositorio (inclusive dependabot). Usa pull_request_target pra
+# poder commitar de volta no branch do PR mesmo quando ele veio de um
+# GITHUB_TOKEN somente-leitura (caso do dependabot em pull_request comum).
+on:
+  pull_request_target:
+    branches: [main, development]
+    paths:
+      - "backend/**"
+      - "mobile/**"
+
+permissions:
+  contents: write
+
+jobs:
+  backend-pint:
+    name: Autofix backend (Pint)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run Pint (fix)
+        run: vendor/bin/pint
+
+      - name: Commit and push fixes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "style(backend): aplica Pint automaticamente"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "Nada para corrigir."
+          fi
+
+  mobile-dart:
+    name: Autofix mobile (dart format)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run dart fix (safe fixes)
+        run: dart fix --apply
+
+      - name: Run dart format
+        run: dart format .
+
+      - name: Commit and push fixes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "style(mobile): aplica dart fix e dart format automaticamente"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "Nada para corrigir."
+          fi

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -4,6 +4,14 @@ name: Autofix (Pint / dart format)
 # proprio repositorio (inclusive dependabot). Usa pull_request_target pra
 # poder commitar de volta no branch do PR mesmo quando ele veio de um
 # GITHUB_TOKEN somente-leitura (caso do dependabot em pull_request comum).
+#
+# O push usa o secret AUTOFIX_PAT (Personal Access Token) em vez do
+# GITHUB_TOKEN padrao. Isso e necessario porque o GitHub nao dispara novos
+# workflows a partir de um push feito com o GITHUB_TOKEN (protecao
+# anti-loop) - sem o PAT, os checks de verdade (Pint --test, flutter
+# analyze, flutter test) nao rodariam de novo no commit corrigido. Sem o
+# secret configurado, cai no GITHUB_TOKEN mesmo assim (correcao ainda
+# acontece, so nao re-dispara os outros checks sozinha).
 on:
   pull_request_target:
     branches: [main, development]
@@ -27,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.AUTOFIX_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -64,6 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.AUTOFIX_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -24,5 +24,12 @@ linter:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
+    # Convencao de nomes de arquivo (PascalCase) e tipos privados em State<>
+    # ja estao consolidados no projeto; renomear tudo agora tem alto risco
+    # de quebra (imports em cascata) para ganho puramente estilistico.
+    file_names: false
+    library_private_types_in_public_api: false
+    sort_child_properties_last: false
+
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/mobile/lib/include/Body.dart
+++ b/mobile/lib/include/Body.dart
@@ -11,7 +11,6 @@ class Body extends StatefulWidget {
 }
 
 class _Body extends State<Body> {
-  static const double navbarHeight = 50.0;
   bool boolMenu = false;
 
   @override

--- a/mobile/lib/include/Navbar.dart
+++ b/mobile/lib/include/Navbar.dart
@@ -46,9 +46,9 @@ class _NavbarState extends State<Navbar> {
   Future<void> getLogged() async {
     final jwt = await DB.instance.getJWT();
 
-    //print("-----------------------------");
-    //print(jwt);
-    //print("-----------------------------");
+    //debugPrint("-----------------------------");
+    //debugPrint(jwt);
+    //debugPrint("-----------------------------");
 
     if (jwt == null) {
       isLogged = false;
@@ -62,7 +62,7 @@ class _NavbarState extends State<Navbar> {
     try {
       final fcm = await DB.instance.getFCM();
       var response = await API().post('auth/logout', {?fcm: fcm});
-      print(response.body);
+      debugPrint(response.body);
     } catch (_) {}
 
     try {
@@ -71,6 +71,7 @@ class _NavbarState extends State<Navbar> {
 
     await getLogged();
 
+    if (!context.mounted) return;
     context.go("/auth/login");
     /*
     Navigator.push(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -27,15 +27,15 @@ void main() async {
 
   // 2. Recupera o token único do seu aparelho de teste
   String? token = await messaging.getToken();
-  print("FCM Token do Aparelho: $token");
+  debugPrint("FCM Token do Aparelho: $token");
 
   await DB.instance.saveFCM(token!);
 
   final fcm = await DB.instance.getFCM();
 
-  print("##########################");
-  print(fcm);
-  print("##########################");
+  debugPrint("##########################");
+  debugPrint(fcm);
+  debugPrint("##########################");
 
   await NotificationService.init(
     onNotificationTap: (data) {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -23,11 +23,7 @@ void main() async {
   final messaging = FirebaseMessaging.instance;
 
   // 1. Solicita permissão de notificação (obrigatório para iOS e Android 13+)
-  NotificationSettings settings = await messaging.requestPermission(
-    alert: true,
-    badge: true,
-    sound: true,
-  );
+  await messaging.requestPermission(alert: true, badge: true, sound: true);
 
   // 2. Recupera o token único do seu aparelho de teste
   String? token = await messaging.getToken();

--- a/mobile/lib/service/API.dart
+++ b/mobile/lib/service/API.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -19,7 +20,7 @@ class API {
       headers["Authorization"] = "Bearer $jwt";
     }
 
-    print("Headers: $headers");
+    debugPrint("Headers: $headers");
 
     return headers;
   }
@@ -30,7 +31,7 @@ class API {
         Uri.parse("$baseURL$url"),
         headers: await _headers(),
       );
-      print("Response: ${response.body}");
+      debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
       return {"error": e.toString()};
@@ -44,7 +45,7 @@ class API {
         headers: await _headers(),
         body: jsonEncode(data),
       );
-      print("Response: ${response.body}");
+      debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
       return {"error": e.toString()};
@@ -58,7 +59,7 @@ class API {
         headers: await _headers(),
         body: jsonEncode(data),
       );
-      print("Response: ${response.body}");
+      debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
       return {"error": e.toString()};
@@ -72,7 +73,7 @@ class API {
         headers: await _headers(),
         body: jsonEncode(data),
       );
-      print("Response: ${response.body}");
+      debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
       return {"error": e.toString()};
@@ -85,7 +86,7 @@ class API {
         Uri.parse("$baseURL$url"),
         headers: await _headers(),
       );
-      print("Response: ${response.body}");
+      debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
       return {"error": e.toString()};
@@ -120,8 +121,8 @@ class API {
       final response = await http.Response.fromStream(streamedResponse);
 
       // Logs
-      print("Status Code: ${response.statusCode}");
-      print("Response Body: ${response.body}");
+      debugPrint("Status Code: ${response.statusCode}");
+      debugPrint("Response Body: ${response.body}");
 
       return response;
     } catch (e) {
@@ -161,7 +162,7 @@ class API {
     // Salva o arquivo
     await file.writeAsBytes(response.bodyBytes);
 
-    print("Arquivo salvo em: ${file.path}");
+    debugPrint("Arquivo salvo em: ${file.path}");
 
     return file;
   }

--- a/mobile/lib/service/ServiceAuth.dart
+++ b/mobile/lib/service/ServiceAuth.dart
@@ -16,15 +16,15 @@ class ServiceAuth {
     return false;
   }
 
-  register() {}
+  void register() {}
 
   Future<bool> logout() async {
     return false;
   }
 
-  forgotPassword() {}
+  void forgotPassword() {}
 
-  verifyOTP() {}
+  void verifyOTP() {}
 
-  resetPassword() {}
+  void resetPassword() {}
 }

--- a/mobile/lib/view/ViewHome.dart
+++ b/mobile/lib/view/ViewHome.dart
@@ -109,9 +109,9 @@ class _ViewHomeState extends State<ViewHome> {
       var userWebData = body['data']['data'];
       //var userWebData = body;
 
-      print("*******************************");
-      print(userWebData);
-      print("*******************************");
+      debugPrint("*******************************");
+      debugPrint(userWebData.toString());
+      debugPrint("*******************************");
 
       for (var data in userWebData) {
         String status = data['status'];
@@ -154,7 +154,9 @@ class _ViewHomeState extends State<ViewHome> {
       state = userData['state'] ?? '';
       country = userData['country'] ?? '';
       linkedinLink = userData['linkedin_link'] ?? '';
-    } catch (e) {}
+    } catch (e) {
+      debugPrint('Erro ao carregar dados do usuario: $e');
+    }
 
     setState(() {
       loading = false;

--- a/mobile/lib/view/ViewHome.dart
+++ b/mobile/lib/view/ViewHome.dart
@@ -3,10 +3,8 @@ import 'dart:convert';
 import 'package:bomcurriculo/include/Navbar.dart';
 import 'package:bomcurriculo/service/API.dart';
 import 'package:bomcurriculo/util/Translation.dart';
-import 'package:bomcurriculo/view/resume/ViewNewResume.dart';
 import 'package:bomcurriculo/widget/WidgetButton.dart';
 import 'package:bomcurriculo/widget/WidgetResume.dart';
-import 'package:bomcurriculo/widget/WidgetScore.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/lib/view/auth/ViewForgotPassword.dart
+++ b/mobile/lib/view/auth/ViewForgotPassword.dart
@@ -1,6 +1,5 @@
 import 'package:bomcurriculo/include/BodyAuth.dart';
 import 'package:bomcurriculo/util/Translation.dart';
-import 'package:bomcurriculo/view/auth/ViewVerifyOTP.dart';
 import 'package:bomcurriculo/widget/WidgetError.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/mobile/lib/view/auth/ViewForgotPassword.dart
+++ b/mobile/lib/view/auth/ViewForgotPassword.dart
@@ -71,6 +71,7 @@ class _ViewForgotPassword extends State<ViewForgotPassword> {
       API api = API();
       await api.post('auth/forgot-password', {'email': controllerEmail.text});
 
+      if (!mounted) return;
       context.go("/auth/verify-otp");
       //Navigator.push(
       //  context,

--- a/mobile/lib/view/auth/ViewLogin.dart
+++ b/mobile/lib/view/auth/ViewLogin.dart
@@ -2,9 +2,6 @@ import 'dart:convert';
 
 import 'package:bomcurriculo/include/BodyAuth.dart';
 import 'package:bomcurriculo/util/Validation.dart';
-import 'package:bomcurriculo/view/ViewHome.dart';
-import 'package:bomcurriculo/view/auth/ViewForgotPassword.dart';
-import 'package:bomcurriculo/view/auth/ViewRegister.dart';
 import 'package:bomcurriculo/widget/WidgetError.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/mobile/lib/view/auth/ViewLogin.dart
+++ b/mobile/lib/view/auth/ViewLogin.dart
@@ -87,9 +87,9 @@ class _ViewLogin extends State<ViewLogin> {
         'password': controllerPassword.text,
         'fcm': fcm,
       };
-      print("**********************************");
-      print(payload);
-      print("**********************************");
+      debugPrint("**********************************");
+      debugPrint(payload.toString());
+      debugPrint("**********************************");
       var response = await api.post('auth/login', payload);
 
       var body = jsonDecode(response.body);
@@ -101,6 +101,7 @@ class _ViewLogin extends State<ViewLogin> {
         String user = jsonEncode(body['data']['user']);
         await DB.instance.saveUser(user);
 
+        if (!mounted) return;
         context.go("/");
         //Navigator.push(
         //  context,

--- a/mobile/lib/view/auth/ViewRegister.dart
+++ b/mobile/lib/view/auth/ViewRegister.dart
@@ -2,8 +2,6 @@ import 'dart:convert';
 
 import 'package:bomcurriculo/include/BodyAuth.dart';
 import 'package:bomcurriculo/util/Translation.dart';
-import 'package:bomcurriculo/view/ViewHome.dart';
-import 'package:bomcurriculo/view/auth/ViewLogin.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/lib/view/auth/ViewRegister.dart
+++ b/mobile/lib/view/auth/ViewRegister.dart
@@ -113,9 +113,9 @@ class _ViewRegister extends State<ViewRegister> {
         'password_confirm': controllerRetypePassword.text,
         'fcm': fcm,
       };
-      print("**********************************");
-      print(payload);
-      print("**********************************");
+      debugPrint("**********************************");
+      debugPrint(payload.toString());
+      debugPrint("**********************************");
       var response = await api.post('auth/register', payload);
 
       var body = jsonDecode(response.body);
@@ -126,6 +126,7 @@ class _ViewRegister extends State<ViewRegister> {
         }
         String user = jsonEncode(body['data']['user']);
         await DB.instance.saveUser(user);
+        if (!mounted) return;
         context.go("/");
         //Navigator.push(
         //  context,

--- a/mobile/lib/view/auth/ViewResetPassword.dart
+++ b/mobile/lib/view/auth/ViewResetPassword.dart
@@ -1,6 +1,5 @@
 import 'package:bomcurriculo/include/BodyAuth.dart';
 import 'package:bomcurriculo/util/Translation.dart';
-import 'package:bomcurriculo/view/auth/ViewLogin.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/lib/view/auth/ViewResetPassword.dart
+++ b/mobile/lib/view/auth/ViewResetPassword.dart
@@ -89,6 +89,7 @@ class _ViewResetPassword extends State<ViewResetPassword> {
         'otp': widget.otp,
       });
 
+      if (!mounted) return;
       if (response.statusCode == 200) {
         context.go("/auth/login");
         //Navigator.push(

--- a/mobile/lib/view/auth/ViewVerifyOTP.dart
+++ b/mobile/lib/view/auth/ViewVerifyOTP.dart
@@ -91,6 +91,7 @@ class _ViewVerifyOTP extends State<ViewVerifyOTP> {
     API api = API();
     var response = await api.post('auth/verify-otp', {'otp': otp});
 
+    if (!mounted) return;
     if (response.statusCode == 200) {
       Navigator.push(
         context,

--- a/mobile/lib/view/resume/ViewNewResume.dart
+++ b/mobile/lib/view/resume/ViewNewResume.dart
@@ -132,6 +132,7 @@ class _ViewNewResume extends State<ViewNewResume> {
       files,
     );
     debugPrint(response.body);
+    if (!mounted) return;
     context.go("/");
     //Navigator.push(
     //  context,

--- a/mobile/lib/view/resume/ViewNewResume.dart
+++ b/mobile/lib/view/resume/ViewNewResume.dart
@@ -112,18 +112,18 @@ class _ViewNewResume extends State<ViewNewResume> {
       }
     }
 
-    print("###############################");
-    print(data);
-    print("###############################");
+    debugPrint("###############################");
+    debugPrint(data.toString());
+    debugPrint("###############################");
 
     var files = [
       {"field": "resume_cv", "path": resumeFile!.path},
       {"field": "resume_linkedin", "path": linkedinFile!.path},
     ];
 
-    print("###############################");
-    print(files);
-    print("###############################");
+    debugPrint("###############################");
+    debugPrint(files.toString());
+    debugPrint("###############################");
 
     //"client/resumes/new-resume",
     final response = await API().upload(
@@ -131,7 +131,7 @@ class _ViewNewResume extends State<ViewNewResume> {
       data,
       files,
     );
-    print(response.body);
+    debugPrint(response.body);
     context.go("/");
     //Navigator.push(
     //  context,

--- a/mobile/lib/widget/WidgetResume.dart
+++ b/mobile/lib/widget/WidgetResume.dart
@@ -1,5 +1,4 @@
 import 'package:bomcurriculo/theme/AppColors.dart';
-import 'package:bomcurriculo/view/resume/ViewGenerateResume.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/lib/widget/WidgetResume.dart
+++ b/mobile/lib/widget/WidgetResume.dart
@@ -56,7 +56,7 @@ class _WidgetResume extends State<WidgetResume> {
           //);
         } else if (widget.type == 'ready') {
           final file = await API().download(widget.downloadURL);
-          print(file.path);
+          debugPrint(file.path);
         }
       },
       child: Column(
@@ -135,7 +135,7 @@ class _WidgetResume extends State<WidgetResume> {
                         final file = await API().download(
                           widget.downloadURL,
                         );
-                        print(file.path);
+                        debugPrint(file.path);
                       },
                       child: Icon(icon)
                     ),

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   lucid_validation: ^1.4.0
   http: ^1.6.0
   sqflite: ^2.4.3
+  path: ^1.9.1
   path_provider: ^2.1.6
   firebase_core: ^4.11.0
   firebase_messaging: ^16.4.1

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,17 +1,28 @@
-// Testa que o app sobe sem lancar excecoes, indo para a tela de login
-// quando o usuario nao esta autenticado.
+// O antigo teste de widget (template padrao do `flutter create`) testava um
+// contador que nao existe no app real e sempre falhava. Testar o app de
+// verdade via WidgetTester exige mockar o sqflite (o Navbar consulta o DB
+// local ja no initState, em toda tela), o que fica para um PR futuro com
+// sqflite_common_ffi. Por ora cobrimos a validacao de email, unit puro e
+// sem dependencia de plataforma.
 
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:bomcurriculo/main.dart';
+import 'package:bomcurriculo/util/Validation.dart';
 
 void main() {
-  testWidgets('App builds and shows the login screen when logged out', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(const MyApp(logged: false));
-    await tester.pumpAndSettle();
+  group('Validation.isEmail', () {
+    final validation = Validation();
 
-    expect(tester.takeException(), isNull);
+    test('aceita um email valido', () {
+      expect(validation.isEmail('usuario@email.com'), isTrue);
+    });
+
+    test('rejeita string sem @', () {
+      expect(validation.isEmail('usuario-email.com'), isFalse);
+    });
+
+    test('rejeita string vazia', () {
+      expect(validation.isEmail(''), isFalse);
+    });
   });
 }

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,30 +1,17 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Testa que o app sobe sem lancar excecoes, indo para a tela de login
+// quando o usuario nao esta autenticado.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:bomcurriculo/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('App builds and shows the login screen when logged out', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(const MyApp(logged: false));
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Duas frentes, pra resolver o padrão de "PR novo sempre quebra por formatação/lint pré-existente" (visto nos PRs #159, #160, #170, #172):

## 1. Baseline do `/mobile` zerado

O `flutter analyze` falha com **qualquer** issue (inclusive nível "info"), então mesmo sem nenhum warning restante, 88 infos derrubavam o CI de qualquer PR que tocasse `/mobile`. Corrigido:

- `print()` → `debugPrint()` em toda a app.
- Guarda `mounted` / `context.mounted` antes de usar `BuildContext` depois de `await` (7 ocorrências).
- 12 warnings reais: imports, campo e variável não usados.
- Pacote `path` declarado no `pubspec.yaml` (estava sendo usado só transitivamente).
- Tipos de retorno explícitos em `ServiceAuth` (estava com inferência implícita).
- Log em vez de `catch` vazio em `ViewHome`.
- `analysis_options.yaml`: desativadas `file_names`, `library_private_types_in_public_api` e `sort_child_properties_last` — são convenção de nomenclatura antiga do projeto (~26 arquivos em PascalCase); renomear tudo agora tem alto risco de quebra (imports em cascata, e esse repo já teve conflito de case-sensitivity com `Dockerfile`) pra um ganho puramente estilístico. Fica registrado como dívida técnica pra um PR dedicado.
- Teste padrão do template (`Counter increments smoke test`, sobra do `flutter create`) estava sempre falhando escondido atrás da falha do `analyze` — trocado por um teste unitário real de `Validation.isEmail`. Um teste de widget completo do app precisa mockar o `sqflite` (o `Navbar` consulta o DB local já no `initState`, em toda tela) — fica de follow-up com `sqflite_common_ffi`.

## 2. Autofix automático (`.github/workflows/autofix.yml`)

Novo workflow que roda `Pint` (backend) e `dart fix --apply` + `dart format` (mobile) em todo PR que toque essas pastas, e **commita a correção de volta no branch do PR automaticamente**. Usa `pull_request_target` pra funcionar mesmo em PRs do Dependabot, que rodam com `GITHUB_TOKEN` somente-leitura no evento `pull_request` normal — só roda em PRs do próprio repositório (sem secrets/permissões de escrita em PRs de fork).

Closes #174
