### PR TITLE
fix(ci): corrige workflow de autofix (versao sem PAT ficou de fora do #175)

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,13 +5,11 @@ name: Autofix (Pint / dart format)
 # poder commitar de volta no branch do PR mesmo quando ele veio de um
 # GITHUB_TOKEN somente-leitura (caso do dependabot em pull_request comum).
 #
-# O push usa o secret AUTOFIX_PAT (Personal Access Token) em vez do
-# GITHUB_TOKEN padrao. Isso e necessario porque o GitHub nao dispara novos
-# workflows a partir de um push feito com o GITHUB_TOKEN (protecao
-# anti-loop) - sem o PAT, os checks de verdade (Pint --test, flutter
-# analyze, flutter test) nao rodariam de novo no commit corrigido. Sem o
-# secret configurado, cai no GITHUB_TOKEN mesmo assim (correcao ainda
-# acontece, so nao re-dispara os outros checks sozinha).
+# O GITHUB_TOKEN nao dispara novos workflows a partir de um push (protecao
+# anti-loop do GitHub) - entao depois de commitar a correcao, disparamos
+# explicitamente os workflows de CI via workflow_dispatch (excecao
+# documentada a essa regra) pra eles rodarem de novo contra o commit
+# corrigido e o PR ficar com os checks reais em dia, sem precisar de PAT.
 on:
   pull_request_target:
     branches: [main, development]
@@ -21,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   backend-pint:
@@ -35,7 +34,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ secrets.AUTOFIX_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -50,6 +48,7 @@ jobs:
         run: vendor/bin/pint
 
       - name: Commit and push fixes
+        id: commit
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
@@ -57,9 +56,17 @@ jobs:
             git add -A
             git commit -m "style(backend): aplica Pint automaticamente"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Nada para corrigir."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Re-disparar Backend CI no commit corrigido
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run backend-ci.yml --ref "${{ github.event.pull_request.head.ref }}"
 
   mobile-dart:
     name: Autofix mobile (dart format)
@@ -73,7 +80,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ secrets.AUTOFIX_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -91,6 +97,7 @@ jobs:
         run: dart format .
 
       - name: Commit and push fixes
+        id: commit
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
@@ -98,6 +105,14 @@ jobs:
             git add -A
             git commit -m "style(mobile): aplica dart fix e dart format automaticamente"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Nada para corrigir."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Re-disparar Mobile CI no commit corrigido
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run mobile-ci.yml --ref "${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"
+  # Permite ao workflow de autofix re-rodar esses checks depois de commitar
+  # uma correcao (push feito com GITHUB_TOKEN nao dispara pull_request de
+  # novo, mas workflow_dispatch e uma excecao a essa regra).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "mobile/**"
       - ".github/workflows/mobile-ci.yml"
+  # Permite ao workflow de autofix re-rodar esses checks depois de commitar
+  # uma correcao (push feito com GITHUB_TOKEN nao dispara pull_request de
+  # novo, mas workflow_dispatch e uma excecao a essa regra).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
O PR #175 foi mergeado antes do meu ultimo push chegar (troca da abordagem
de PAT pra workflow_dispatch), entao a `development` ficou com uma versao
do `autofix.yml` que referencia um secret `AUTOFIX_PAT` inexistente.

Este PR traz a versao final: sem depender de nenhum secret, usa
`workflow_dispatch` (excecao documentada a regra anti-loop do GITHUB_TOKEN)
pra redisparar o Backend CI / Mobile CI depois de corrigir o style.