### PR TITLE
ci: registra workflow de autofix (Pint/dart format) na main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,118 @@
+name: Autofix (Pint / dart format)
+
+# Roda com permissoes de escrita e sem segredos de fork: so aceita PRs do
+# proprio repositorio (inclusive dependabot). Usa pull_request_target pra
+# poder commitar de volta no branch do PR mesmo quando ele veio de um
+# GITHUB_TOKEN somente-leitura (caso do dependabot em pull_request comum).
+#
+# O GITHUB_TOKEN nao dispara novos workflows a partir de um push (protecao
+# anti-loop do GitHub) - entao depois de commitar a correcao, disparamos
+# explicitamente os workflows de CI via workflow_dispatch (excecao
+# documentada a essa regra) pra eles rodarem de novo contra o commit
+# corrigido e o PR ficar com os checks reais em dia, sem precisar de PAT.
+on:
+  pull_request_target:
+    branches: [main, development]
+    paths:
+      - "backend/**"
+      - "mobile/**"
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  backend-pint:
+    name: Autofix backend (Pint)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run Pint (fix)
+        run: vendor/bin/pint
+
+      - name: Commit and push fixes
+        id: commit
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "style(backend): aplica Pint automaticamente"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nada para corrigir."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-disparar Backend CI no commit corrigido
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run backend-ci.yml --ref "${{ github.event.pull_request.head.ref }}"
+
+  mobile-dart:
+    name: Autofix mobile (dart format)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run dart fix (safe fixes)
+        run: dart fix --apply
+
+      - name: Run dart format
+        run: dart format .
+
+      - name: Commit and push fixes
+        id: commit
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "style(mobile): aplica dart fix e dart format automaticamente"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nada para corrigir."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-disparar Mobile CI no commit corrigido
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run mobile-ci.yml --ref "${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"
+  # Permite ao workflow de autofix re-rodar esses checks depois de commitar
+  # uma correcao (push feito com GITHUB_TOKEN nao dispara pull_request de
+  # novo, mas workflow_dispatch e uma excecao a essa regra).
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "mobile/**"
       - ".github/workflows/mobile-ci.yml"
+  # Permite ao workflow de autofix re-rodar esses checks depois de commitar
+  # uma correcao (push feito com GITHUB_TOKEN nao dispara pull_request de
+  # novo, mas workflow_dispatch e uma excecao a essa regra).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
O GitHub só registra/ativa um workflow novo quando o arquivo `.github/workflows/*.yml` existe no branch padrão do repositório (`main`). O `autofix.yml` foi mergeado só na `development` (#175) e por isso nunca rodou — nem aparece na lista de workflows ativos do repo.

Este PR leva o `autofix.yml` (versão final, sem depender de secret/PAT — usa `workflow_dispatch`) e os ajustes de `workflow_dispatch` no `backend-ci.yml`/`mobile-ci.yml` direto pra `main`.

Depois disso mergear, o autofix passa a valer pra PRs abertos contra `main` **e** `development`.