### PR TITLE
chore(backend): remove arquivo de teste descartavel do autofix

### DIFF
--- a/backend/tests/Feature/AutofixCheckTest.php
+++ b/backend/tests/Feature/AutofixCheckTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('is a throwaway test to check the autofix workflow',function(){
-    expect(true)->toBeTrue();
-});

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -377,7 +377,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"


### PR DESCRIPTION
O #176 foi mergeado antes do autofix workflow ficar ativo (dependia do #178 chegar na main), entao o arquivo de teste mal formatado foi parar na development sem correcao e quebrou o Pint. Removendo — ele nunca teve funcao real, era so pra validar o workflow.