### PR TITLE
test: validar autofix de verdade (workflow ja ativo)

### DIFF
--- a/backend/tests/Feature/AutofixCheckTest.php
+++ b/backend/tests/Feature/AutofixCheckTest.php
@@ -1,9 +1,9 @@
 <?php
 
-it('is a throwaway test to check the autofix workflow',function(){
+it('is a throwaway test to check the autofix workflow', function () {
     expect(true)->toBeTrue();
 });
 
-it('is a second throwaway test to confirm the autofix workflow really runs',function(){
-    expect(1+1)->toBe(2);
+it('is a second throwaway test to confirm the autofix workflow really runs', function () {
+    expect(1 + 1)->toBe(2);
 });

--- a/backend/tests/Feature/AutofixCheckTest.php
+++ b/backend/tests/Feature/AutofixCheckTest.php
@@ -3,3 +3,7 @@
 it('is a throwaway test to check the autofix workflow',function(){
     expect(true)->toBeTrue();
 });
+
+it('is a second throwaway test to confirm the autofix workflow really runs',function(){
+    expect(1+1)->toBe(2);
+});


### PR DESCRIPTION
PR de teste — o #176 nao serviu porque o autofix so ficou ativo depois (via #178). Agora que ta ativo, este PR tem o mesmo tipo de erro de estilo pra confirmar que o autofix corrige e redispara os checks sozinho. Fechar/deletar depois.