### PR TITLE
Feature: adiciona testes pros endpoints da api que ainda nao tinham

### DIFF
--- a/backend/tests/Feature/Auth/LogoutTest.php
+++ b/backend/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\UserDevice;
+
+it('revokes the current access token', function () {
+
+    $auth = actingAsUser();
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/auth/logout');
+
+    $response->assertOk()
+        ->assertJson([
+            'message' => 'Logged out successfully',
+        ]);
+
+    expect($auth['user']->fresh()->tokens()->count())->toBe(0);
+});
+
+it('removes the device matching the given fcm token', function () {
+
+    $auth = actingAsUser();
+
+    UserDevice::create([
+        'user_id' => $auth['user']->id,
+        'fcm_token' => 'token-fcm-123',
+    ]);
+
+    $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/auth/logout', [
+            'fcm' => 'token-fcm-123',
+        ])
+        ->assertOk();
+
+    $this->assertDatabaseMissing('user_devices', [
+        'user_id' => $auth['user']->id,
+        'fcm_token' => 'token-fcm-123',
+    ]);
+});
+
+it('requires authentication', function () {
+
+    $this->postJson('/api/auth/logout')
+        ->assertUnauthorized();
+});

--- a/backend/tests/Feature/Auth/ResetPasswordTest.php
+++ b/backend/tests/Feature/Auth/ResetPasswordTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Models\PasswordResetOtp;
+use Illuminate\Support\Facades\Hash;
+
+it('resets the password with a valid, already-verified otp', function () {
+
+    $user = authUser([
+        'password' => Hash::make('senha-antiga'),
+    ]);
+
+    PasswordResetOtp::create([
+        'user_id' => $user->id,
+        'otp' => 123456,
+        'expires_at' => now()->addMinutes(10),
+        'used_at' => now(),
+    ]);
+
+    $response = $this->postJson('/api/auth/reset-password', [
+        'otp' => 123456,
+        'password' => 'senha-nova-123',
+        'password_confirm' => 'senha-nova-123',
+    ]);
+
+    $response->assertOk()
+        ->assertJson([
+            'message' => 'Password reset successfully',
+        ]);
+
+    expect(Hash::check('senha-nova-123', $user->fresh()->password))->toBeTrue();
+
+    $this->assertDatabaseMissing('password_reset_otps', [
+        'otp' => 123456,
+    ]);
+});
+
+it('returns 500 when the otp was never verified', function () {
+
+    $user = authUser();
+
+    PasswordResetOtp::create([
+        'user_id' => $user->id,
+        'otp' => 654321,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $response = $this->postJson('/api/auth/reset-password', [
+        'otp' => 654321,
+        'password' => 'senha-nova-123',
+        'password_confirm' => 'senha-nova-123',
+    ]);
+
+    $response->assertServerError();
+});
+
+it('returns 422 when passwords do not match', function () {
+
+    $user = authUser();
+
+    PasswordResetOtp::create([
+        'user_id' => $user->id,
+        'otp' => 111111,
+        'expires_at' => now()->addMinutes(10),
+        'used_at' => now(),
+    ]);
+
+    $response = $this->postJson('/api/auth/reset-password', [
+        'otp' => 111111,
+        'password' => 'senha-nova-123',
+        'password_confirm' => 'senha-diferente',
+    ]);
+
+    $response->assertUnprocessable();
+});

--- a/backend/tests/Feature/Resume/ProcessResumeTest.php
+++ b/backend/tests/Feature/Resume/ProcessResumeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Jobs\Api\RabbitMQ\Resumes\ResumeProcessingPublisher;
+use Illuminate\Support\Facades\Queue;
+
+it('dispatches the resume processing job for the authenticated user', function () {
+
+    Queue::fake();
+
+    $auth = actingAsUser();
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/rabbitmq/process');
+
+    $response->assertOk()
+        ->assertJson([
+            'message' => 'Success',
+        ]);
+
+    Queue::assertPushed(ResumeProcessingPublisher::class, function ($job) use ($auth) {
+        return $job->user_id === $auth['user']->id;
+    });
+});
+
+it('requires authentication', function () {
+
+    $this->postJson('/api/client/services/rabbitmq/process')
+        ->assertUnauthorized();
+});
+
+it('currently breaks with a server error when user_resume_id is sent', function () {
+
+    // Known bug (not fixed here, only documented): the controller passes the raw
+    // id straight into ResumeProcessingPublisher's constructor, which type-hints
+    // ?UserResume, not an id. This test locks in the current (broken) behavior so
+    // a future fix is a visible, intentional test change instead of a silent one.
+    Queue::fake();
+
+    $auth = actingAsUser();
+    $resume = $auth['user']->resumes()->create([
+        'original_file_path_cv' => 'resumes/cv.pdf',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/rabbitmq/process', [
+            'user_resume_id' => $resume->id,
+        ]);
+
+    $response->assertServerError();
+});

--- a/backend/tests/Feature/Resume/ResumeAnalyticsTest.php
+++ b/backend/tests/Feature/Resume/ResumeAnalyticsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+it('lists the user resume analytics ordered from newest to oldest', function () {
+
+    $auth = actingAsUser();
+
+    $this->travelTo(now()->subDay());
+    $older = $auth['user']->resumeAnalytics()->create([
+        'status' => 'pending',
+    ]);
+
+    $this->travelBack();
+    $newer = $auth['user']->resumeAnalytics()->create([
+        'status' => 'pending',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson('/api/client/resumes/pendings');
+
+    $response->assertOk();
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids->first())->toBe($newer->id)
+        ->and($ids->last())->toBe($older->id);
+});
+
+it('does not list analytics belonging to another user', function () {
+
+    $auth = actingAsUser();
+    $otherUser = authUser();
+
+    $otherUser->resumeAnalytics()->create(['status' => 'pending']);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson('/api/client/resumes/pendings');
+
+    $response->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('requires authentication', function () {
+
+    $this->getJson('/api/client/resumes/pendings')
+        ->assertUnauthorized();
+});

--- a/backend/tests/Feature/Resume/ShowPendingResumeTest.php
+++ b/backend/tests/Feature/Resume/ShowPendingResumeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+it('shows a resume analytic belonging to the authenticated user', function () {
+
+    $auth = actingAsUser();
+
+    $analytic = $auth['user']->resumeAnalytics()->create([
+        'status' => 'pending',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson("/api/client/resumes/pendings/{$analytic->id}");
+
+    $response->assertOk()
+        ->assertJson([
+            'data' => [
+                'id' => $analytic->id,
+            ],
+        ]);
+});
+
+it('returns 404 for a resume analytic belonging to another user', function () {
+
+    $auth = actingAsUser();
+    $otherUser = authUser();
+
+    $analytic = $otherUser->resumeAnalytics()->create([
+        'status' => 'pending',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson("/api/client/resumes/pendings/{$analytic->id}");
+
+    $response->assertNotFound();
+});
+
+it('returns 404 for a nonexistent resume analytic', function () {
+
+    $auth = actingAsUser();
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson('/api/client/resumes/pendings/999999');
+
+    $response->assertNotFound();
+});
+
+it('requires authentication', function () {
+
+    $this->getJson('/api/client/resumes/pendings/1')
+        ->assertUnauthorized();
+});

--- a/backend/tests/Feature/Resume/StoreNewResumeTest.php
+++ b/backend/tests/Feature/Resume/StoreNewResumeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+it('uploads cv and linkedin files and creates a resume record', function () {
+
+    Storage::fake('local');
+
+    $auth = actingAsUser();
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'resume_cv' => UploadedFile::fake()->create('cv.pdf', 100),
+            'resume_linkedin' => UploadedFile::fake()->create('linkedin.pdf', 100),
+            'github_link' => 'https://github.com/pedroaruana',
+            'site_link' => 'https://pedroaruana.dev',
+        ]);
+
+    $response->assertOk()
+        ->assertJson([
+            'message' => 'User Updated',
+        ]);
+
+    $user = $auth['user']->fresh();
+    expect($user->github_link)->toBe('https://github.com/pedroaruana')
+        ->and($user->site_link)->toBe('https://pedroaruana.dev')
+        ->and($user->resume_cv)->not->toBeNull()
+        ->and($user->resume_linkedin)->not->toBeNull();
+
+    Storage::disk('local')->assertExists($user->resume_cv);
+
+    $this->assertDatabaseHas('user_resumes', [
+        'user_id' => $user->id,
+    ]);
+});
+
+it('processes the skills sent along with the resume', function () {
+
+    Storage::fake('local');
+
+    $auth = actingAsUser();
+
+    $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'skills' => [
+                ['name' => 'PHP'],
+                ['name' => 'Laravel'],
+            ],
+        ])
+        ->assertOk();
+
+    expect($auth['user']->skills()->pluck('name')->all())->toBe(['PHP', 'Laravel']);
+});
+
+it('works with only links, no files', function () {
+
+    $auth = actingAsUser();
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'github_link' => 'https://github.com/pedroaruana',
+        ]);
+
+    $response->assertOk();
+
+    $this->assertDatabaseMissing('user_resumes', [
+        'user_id' => $auth['user']->id,
+    ]);
+});
+
+it('requires authentication', function () {
+
+    $this->postJson('/api/client/resumes/new-resume')
+        ->assertUnauthorized();
+});

--- a/backend/tests/Feature/User/GetUserResumesTest.php
+++ b/backend/tests/Feature/User/GetUserResumesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+it('lists the user resumes ordered from newest to oldest', function () {
+
+    $auth = actingAsUser();
+
+    $this->travelTo(now()->subDay());
+    $older = $auth['user']->resumes()->create([
+        'original_file_path_cv' => 'resumes/old-cv.pdf',
+    ]);
+
+    $this->travelBack();
+    $newer = $auth['user']->resumes()->create([
+        'original_file_path_cv' => 'resumes/new-cv.pdf',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson('/api/client/user/resumes');
+
+    $response->assertOk();
+
+    $ids = collect($response->json('data.data'))->pluck('id');
+    expect($ids->first())->toBe($newer->id)
+        ->and($ids->last())->toBe($older->id);
+});
+
+it('does not list resumes belonging to another user', function () {
+
+    $auth = actingAsUser();
+    $otherUser = authUser();
+
+    $otherUser->resumes()->create([
+        'original_file_path_cv' => 'resumes/other-cv.pdf',
+    ]);
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->getJson('/api/client/user/resumes');
+
+    $response->assertOk()
+        ->assertJsonCount(0, 'data.data');
+});
+
+it('requires authentication', function () {
+
+    $this->getJson('/api/client/user/resumes')
+        ->assertUnauthorized();
+});


### PR DESCRIPTION
## Description

Resolve a issue #135
- 7 endpoints da api ainda nao tinham teste: logout, redefinir senha, 
  listar curriculos do usuario, enviar novo curriculo, listar analises, 
  ver analise especifica e disparar processamento
- adicionei os 7 testes cobrindo caminho feliz, validacao e autenticacao
obs: no meio do caminho achei 2 bugs reais no endpoint do rabbitmq 
(/client/services/rabbitmq/process) - ja documentei com o flavio no discord, 
nao corrigi porque nao tem a ver com essa issue, so deixei um teste que 
confirma o comportamento atual



## AI Usage

* [x] Vibe coding
* [ ] Research

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area

* [ ] Frontend
* [x] Backend
* [ ] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [ ] Added/updated tests when necessary
* [ ] Updated the documentation when necessary

## How to test

1. entra na pasta backend
2. roda composer install
3. roda php artisan test
4. deve mostrar 70 testes passando
<img width="737" height="438" alt="Captura de tela 2026-07-23 142225" src="https://github.com/user-attachments/assets/306a777a-83fc-4aa0-b51b-41ebc13690ae" />