### PR TITLE
feat: altera css padrao por tailwind da tela my-curriculum

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3320,9 +3320,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3338,9 +3335,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3358,9 +3352,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3376,9 +3367,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3396,9 +3384,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,9 +3399,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3685,9 +3667,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3703,9 +3682,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3723,9 +3699,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3741,9 +3714,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/frontend/src/pages/dashboard/my-curriculum/SendCurriculumForm.tsx
+++ b/frontend/src/pages/dashboard/my-curriculum/SendCurriculumForm.tsx
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import axios from 'axios';
-import { 
-  Upload, 
-  Link as LinkIcon, 
-  Code2, 
-  FileText, 
-  Plus, 
-  Trash2, 
-  Send, 
-  CheckCircle2, 
-  AlertCircle 
+import {
+  Upload,
+  Link as LinkIcon,
+  Code2,
+  FileText,
+  Plus,
+  Trash2,
+  Send,
+  CheckCircle2,
+  AlertCircle
 } from 'lucide-react';
 
 export interface Skill {
@@ -28,7 +28,7 @@ export default function SendCurriculumForm() {
   const [linkedinPdf, setLinkedinPdf] = useState<File | null>(null);
   const [githubUrl, setGithubUrl] = useState<string>('');
   const [portfolioUrl, setPortfolioUrl] = useState<string>('');
-  
+
   const [skills, setSkills] = useState<Skill[]>([]);
   const [currentSkill, setCurrentSkill] = useState<string>('');
   const [currentYears, setCurrentYears] = useState<string>('');
@@ -70,9 +70,9 @@ export default function SendCurriculumForm() {
     e.preventDefault();
 
     if (!resumePdf) {
-      setStatusMessage({ 
-        type: 'error', 
-        text: 'Por favor, anexe o PDF do seu currículo atual (obrigatório).' 
+      setStatusMessage({
+        type: 'error',
+        text: 'Por favor, anexe o PDF do seu currículo atual (obrigatório).'
       });
       return;
     }
@@ -94,11 +94,11 @@ export default function SendCurriculumForm() {
         },
       });
 
-      setStatusMessage({ 
-        type: 'success', 
-        text: 'Dados enviados com sucesso! A IA está processando o currículo.' 
+      setStatusMessage({
+        type: 'success',
+        text: 'Dados enviados com sucesso! A IA está processando o currículo.'
       });
-      
+
       setResumePdf(null);
       setLinkedinPdf(null);
       setGithubUrl('');
@@ -107,9 +107,9 @@ export default function SendCurriculumForm() {
     } catch (error) {
       console.error('Erro ao enviar formulário:', error);
       const apiErrorMessage = (error as { response?: { data?: { message?: string } } })?.response?.data?.message;
-      setStatusMessage({ 
-        type: 'error', 
-        text: apiErrorMessage || 'Erro ao conectar com o servidor. Tente novamente.' 
+      setStatusMessage({
+        type: 'error',
+        text: apiErrorMessage || 'Erro ao conectar com o servidor. Tente novamente.'
       });
     } finally {
       setLoading(false);
@@ -117,51 +117,50 @@ export default function SendCurriculumForm() {
   };
 
   return (
-    <div style={styles.container}>
-      <header style={styles.header}>
-        <h1 style={styles.title}>Otimizar Novo Currículo</h1>
-        <p style={styles.subtitle}>
+    <div className="mx-auto max-w-[850px] px-4 py-6 font-sans text-slate-900">
+      <header className="mb-6">
+        <h1 className="mb-2 text-[28px] font-bold text-gray-950">Otimizar Novo Currículo</h1>
+        <p className="text-[15px] text-slate-500">
           Preencha as informações abaixo para que a IA gere uma versão otimizada para ATS.
         </p>
       </header>
 
-      <form onSubmit={handleSubmit} style={styles.formCard}>
-        
-        {/* DOCUMENTOS */}
-        <section style={styles.section}>
-          <h2 style={styles.sectionTitle}>1. Documentos PDF</h2>
-          <div style={styles.grid2}>
-            
-            <div style={styles.fieldGroup}>
-              <label style={styles.label}>
-                Currículo Atual (PDF) <span style={styles.required}>*</span>
+      <form onSubmit={handleSubmit} className="rounded-2xl border border-slate-200 bg-white p-8 shadow-[0_4px_12px_rgba(0,0,0,0.03)]">
+
+        <section className="mb-5">
+          <h2 className="mb-4 text-lg font-semibold text-slate-800">1. Documentos PDF</h2>
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-5">
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-slate-700">
+                Currículo Atual (PDF) <span className="text-red-500">*</span>
               </label>
-              <div style={styles.fileUploadBox}>
-                <input 
-                  type="file" 
-                  accept=".pdf" 
+              <div className="cursor-pointer rounded-[10px] border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-3">
+                <input
+                  type="file"
+                  accept=".pdf"
                   id="resume_pdf"
-                  style={{ display: 'none' }} 
+                  className="hidden"
                   onChange={handleResumeChange}
                 />
-                <label htmlFor="resume_pdf" style={styles.fileUploadLabel}>
+                <label htmlFor="resume_pdf" className="flex cursor-pointer items-center gap-2.5 text-sm font-medium text-slate-600">
                   <Upload size={20} color="#2563eb" />
                   <span>{resumePdf ? resumePdf.name : 'Selecionar arquivo PDF'}</span>
                 </label>
               </div>
             </div>
 
-            <div style={styles.fieldGroup}>
-              <label style={styles.label}>PDF do Perfil do LinkedIn (Opcional)</label>
-              <div style={styles.fileUploadBox}>
-                <input 
-                  type="file" 
-                  accept=".pdf" 
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-slate-700">PDF do Perfil do LinkedIn (Opcional)</label>
+              <div className="cursor-pointer rounded-[10px] border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-3">
+                <input
+                  type="file"
+                  accept=".pdf"
                   id="linkedin_pdf"
-                  style={{ display: 'none' }} 
+                  className="hidden"
                   onChange={handleLinkedinChange}
                 />
-                <label htmlFor="linkedin_pdf" style={styles.fileUploadLabel}>
+                <label htmlFor="linkedin_pdf" className="flex cursor-pointer items-center gap-2.5 text-sm font-medium text-slate-600">
                   <FileText size={20} color="#0077b5" />
                   <span>{linkedinPdf ? linkedinPdf.name : 'Selecionar PDF do LinkedIn'}</span>
                 </label>
@@ -171,37 +170,36 @@ export default function SendCurriculumForm() {
           </div>
         </section>
 
-        <hr style={styles.divider} />
+        <hr className="my-6 border-0 border-t border-slate-100" />
 
-        {/* LINKS */}
-        <section style={styles.section}>
-          <h2 style={styles.sectionTitle}>2. Links e Presença Digital</h2>
-          <div style={styles.grid2}>
-            
-            <div style={styles.fieldGroup}>
-              <label style={styles.label}>Link do GitHub</label>
-              <div style={styles.inputWithIcon}>
-                <Code2 size={18} color="#64748b" style={styles.inputIcon} />
-                <input 
-                  type="url" 
+        <section className="mb-5">
+          <h2 className="mb-4 text-lg font-semibold text-slate-800">2. Links e Presença Digital</h2>
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-5">
+
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-slate-700">Link do GitHub</label>
+              <div className="relative flex items-center">
+                <Code2 size={18} color="#64748b" className="absolute left-3" />
+                <input
+                  type="url"
                   placeholder="https://github.com/seu-usuario"
                   value={githubUrl}
                   onChange={(e) => setGithubUrl(e.target.value)}
-                  style={styles.input}
+                  className="box-border w-full rounded-lg border border-slate-300 bg-white py-3 pl-10 pr-3 text-sm outline-none"
                 />
               </div>
             </div>
 
-            <div style={styles.fieldGroup}>
-              <label style={styles.label}>Link do Portfólio / Site</label>
-              <div style={styles.inputWithIcon}>
-                <LinkIcon size={18} color="#64748b" style={styles.inputIcon} />
-                <input 
-                  type="url" 
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-slate-700">Link do Portfólio / Site</label>
+              <div className="relative flex items-center">
+                <LinkIcon size={18} color="#64748b" className="absolute left-3" />
+                <input
+                  type="url"
                   placeholder="https://seu-portfolio.com"
                   value={portfolioUrl}
                   onChange={(e) => setPortfolioUrl(e.target.value)}
-                  style={styles.input}
+                  className="box-border w-full rounded-lg border border-slate-300 bg-white py-3 pl-10 pr-3 text-sm outline-none"
                 />
               </div>
             </div>
@@ -209,45 +207,50 @@ export default function SendCurriculumForm() {
           </div>
         </section>
 
-        <hr style={styles.divider} />
+        <hr className="my-6 border-0 border-t border-slate-100" />
 
-        {/* HABILIDADES */}
-        <section style={styles.section}>
-          <h2 style={styles.sectionTitle}>3. Habilidades Principais</h2>
-          <p style={styles.helperText}>Adicione suas hard skills e o tempo de experiência em cada uma.</p>
+        <section className="mb-5">
+          <h2 className="mb-4 text-lg font-semibold text-slate-800">3. Habilidades Principais</h2>
+          <p className="-mt-2 mb-3 text-[13px] text-slate-500">Adicione suas hard skills e o tempo de experiência em cada uma.</p>
 
-          <div style={styles.skillInputGrid}>
-            <input 
-              type="text" 
+          <div className="mb-4 flex flex-wrap gap-2.5">
+            <input
+              type="text"
               placeholder="Ex: React, TypeScript, Node.js..."
               value={currentSkill}
               onChange={(e) => setCurrentSkill(e.target.value)}
-              style={{ ...styles.input, flex: '2 1 200px', paddingLeft: '14px' }}
+              className="box-border rounded-lg border border-slate-300 bg-white py-3 pl-3.5 pr-3 text-sm outline-none"
+              style={{ flex: '2 1 200px' }}
             />
-            <input 
-              type="number" 
+            <input
+              type="number"
               placeholder="Anos"
               min="0"
               max="50"
               value={currentYears}
               onChange={(e) => setCurrentYears(e.target.value)}
-              style={{ ...styles.input, flex: '1 1 100px', paddingLeft: '14px' }}
+              className="box-border rounded-lg border border-slate-300 bg-white py-3 pl-3.5 pr-3 text-sm outline-none"
+              style={{ flex: '1 1 100px' }}
             />
-            <button type="button" onClick={handleAddSkill} style={styles.addSkillBtn}>
+            <button
+              type="button"
+              onClick={handleAddSkill}
+              className="flex h-[42px] items-center gap-1.5 rounded-lg border border-blue-200 bg-blue-50 px-4 text-sm font-semibold text-blue-600"
+            >
               <Plus size={18} />
               <span>Adicionar</span>
             </button>
           </div>
 
           {skills.length > 0 && (
-            <div style={styles.skillsList}>
+            <div className="mt-3 flex flex-wrap gap-2">
               {skills.map((item, index) => (
-                <div key={index} style={styles.skillBadge}>
+                <div key={index} className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-3 py-1.5 text-[13px] text-slate-700">
                   <span><strong>{item.name}</strong> ({item.years} {item.years === 1 ? 'ano' : 'anos'})</span>
-                  <button 
-                    type="button" 
-                    onClick={() => handleRemoveSkill(index)} 
-                    style={styles.removeSkillBtn}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveSkill(index)}
+                    className="flex items-center border-none bg-transparent p-0 text-slate-400"
                     title="Remover habilidade"
                   >
                     <Trash2 size={14} />
@@ -259,14 +262,24 @@ export default function SendCurriculumForm() {
         </section>
 
         {statusMessage && (
-          <div style={statusMessage.type === 'error' ? styles.errorMessage : styles.successMessage}>
+          <div
+            className={`mt-4 flex items-center gap-2 rounded-lg px-4 py-3 text-sm ${
+              statusMessage.type === 'error'
+                ? 'bg-red-50 text-red-800'
+                : 'bg-green-50 text-green-800'
+            }`}
+          >
             {statusMessage.type === 'error' ? <AlertCircle size={20} /> : <CheckCircle2 size={20} />}
             <span>{statusMessage.text}</span>
           </div>
         )}
 
-        <div style={styles.footer}>
-          <button type="submit" disabled={loading} style={styles.submitBtn}>
+        <div className="mt-6 flex justify-end">
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex items-center gap-2 rounded-[10px] bg-[#031b5b] px-7 py-3.5 text-[15px] font-semibold text-white shadow-[0_4px_12px_rgba(3,7,18,0.15)]"
+          >
             <Send size={18} />
             <span>{loading ? 'Processando dados...' : 'Gerar Currículo com IA'}</span>
           </button>
@@ -276,194 +289,3 @@ export default function SendCurriculumForm() {
     </div>
   );
 }
-
-const styles: { [key: string]: React.CSSProperties } = {
-  container: {
-    maxWidth: '850px',
-    margin: '0 auto',
-    padding: '24px 16px',
-    fontFamily: 'Inter, system-ui, -apple-system, sans-serif',
-    color: '#0f172a',
-  },
-  header: {
-    marginBottom: '24px',
-  },
-  title: {
-    fontSize: '28px',
-    fontWeight: '700',
-    color: '#030712',
-    margin: '0 0 8px 0',
-  },
-  subtitle: {
-    fontSize: '15px',
-    color: '#64748b',
-    margin: 0,
-  },
-  formCard: {
-    backgroundColor: '#ffffff',
-    borderRadius: '16px',
-    padding: '32px',
-    border: '1px solid #e2e8f0',
-    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.03)',
-  },
-  section: {
-    marginBottom: '20px',
-  },
-  sectionTitle: {
-    fontSize: '18px',
-    fontWeight: '600',
-    color: '#1e293b',
-    marginBottom: '16px',
-  },
-  grid2: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-    gap: '20px',
-  },
-  fieldGroup: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '8px',
-  },
-  label: {
-    fontSize: '14px',
-    fontWeight: '500',
-    color: '#334155',
-  },
-  required: {
-    color: '#ef4444',
-  },
-  fileUploadBox: {
-    border: '2px dashed #cbd5e1',
-    borderRadius: '10px',
-    padding: '12px 16px',
-    backgroundColor: '#f8fafc',
-    cursor: 'pointer',
-  },
-  fileUploadLabel: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '10px',
-    cursor: 'pointer',
-    fontSize: '14px',
-    color: '#475569',
-    fontWeight: '500',
-  },
-  inputWithIcon: {
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-  },
-  inputIcon: {
-    position: 'absolute',
-    left: '12px',
-  },
-  input: {
-    width: '100%',
-    padding: '12px 12px 12px 40px',
-    fontSize: '14px',
-    borderRadius: '8px',
-    border: '1px solid #cbd5e1',
-    outline: 'none',
-    backgroundColor: '#ffffff',
-    boxSizing: 'border-box',
-  },
-  helperText: {
-    fontSize: '13px',
-    color: '#64748b',
-    marginTop: '-8px',
-    marginBottom: '12px',
-  },
-  skillInputGrid: {
-    display: 'flex',
-    gap: '10px',
-    marginBottom: '16px',
-    flexWrap: 'wrap',
-  },
-  addSkillBtn: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    backgroundColor: '#eff6ff',
-    color: '#2563eb',
-    border: '1px solid #bfdbfe',
-    padding: '0 16px',
-    borderRadius: '8px',
-    fontWeight: '600',
-    cursor: 'pointer',
-    fontSize: '14px',
-    height: '42px',
-  },
-  skillsList: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: '8px',
-    marginTop: '12px',
-  },
-  skillBadge: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '8px',
-    backgroundColor: '#f1f5f9',
-    color: '#334155',
-    padding: '6px 12px',
-    borderRadius: '20px',
-    fontSize: '13px',
-    border: '1px solid #e2e8f0',
-  },
-  removeSkillBtn: {
-    background: 'none',
-    border: 'none',
-    color: '#94a3b8',
-    cursor: 'pointer',
-    display: 'flex',
-    alignItems: 'center',
-    padding: 0,
-  },
-  divider: {
-    border: 0,
-    borderTop: '1px solid #f1f5f9',
-    margin: '24px 0',
-  },
-  footer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    marginTop: '24px',
-  },
-  submitBtn: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    backgroundColor: '#031b5b',
-    color: '#ffffff',
-    border: 'none',
-    padding: '14px 28px',
-    borderRadius: '10px',
-    fontSize: '15px',
-    fontWeight: '600',
-    cursor: 'pointer',
-    boxShadow: '0 4px 12px rgba(3, 7, 18, 0.15)',
-  },
-  errorMessage: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    backgroundColor: '#fef2f2',
-    color: '#991b1b',
-    padding: '12px 16px',
-    borderRadius: '8px',
-    marginTop: '16px',
-    fontSize: '14px',
-  },
-  successMessage: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    backgroundColor: '#f0fdf4',
-    color: '#166534',
-    padding: '12px 16px',
-    borderRadius: '8px',
-    marginTop: '16px',
-    fontSize: '14px',
-  },
-};

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -19,6 +19,7 @@ export function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
       <Route path="/forgot-password" element={<ForgotPassword />} />
+      
 
       <Route element={<ProtectedRoute />}>
         <Route path="/" element={<Home />} />


### PR DESCRIPTION
## Description

Substituição do CSS padrão do frontend pelo Tailwind CSS, refatorando a estilização das páginas para utilizar classes utilitárias, garantindo maior manutenibilidade e um design responsivo/moderno.

## AI Usage

* [ ] Vibe coding
* [x] Research

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area

* [x] Frontend
* [ ] Backend
* [ ] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [ ] Added/updated tests when necessary
* [ ] Updated the documentation when necessary

## How to test

1. Baixe a branch localmente e instale as dependências executando `npm install` (ou `yarn install`) na pasta do frontend.
2. Inicie a aplicação no ambiente local (`npm run dev` ou `npm start`).
3. Navegue pelas páginas da aplicação no navegador para verificar se a nova interface estilizada com Tailwind CSS está sendo renderizada corretamente e de forma responsiva.