### PR TITLE
fix(frontend): move NAV_LINKS para arquivo separado do Header

### DIFF
--- a/frontend/src/components/Home/Header.tsx
+++ b/frontend/src/components/Home/Header.tsx
@@ -22,14 +22,7 @@ import { Link, NavLink, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { LogoutApi } from "@/api/auth/logout-api";
 import { useState } from "react";
-
-export const NAV_LINKS = [
-  { label: "Início", to: "/" },
-  { label: "Dashboard", to: "/dashboard" },
-  { label: "Editor", to: null },
-  { label: "Vagas", to: null },
-  { label: "Preços", to: null },
-];
+import { NAV_LINKS } from "./nav-links";
 
 export function Header() {
   const queryClient = useQueryClient();

--- a/frontend/src/components/Home/nav-links.ts
+++ b/frontend/src/components/Home/nav-links.ts
@@ -1,0 +1,7 @@
+export const NAV_LINKS = [
+  { label: "Início", to: "/" },
+  { label: "Dashboard", to: "/dashboard" },
+  { label: "Editor", to: null },
+  { label: "Vagas", to: null },
+  { label: "Preços", to: null },
+];

--- a/frontend/src/test/components/Home/Header.test.tsx
+++ b/frontend/src/test/components/Home/Header.test.tsx
@@ -1,4 +1,5 @@
-import { Header, NAV_LINKS } from "@/components/Home/Header";
+import { Header } from "@/components/Home/Header";
+import { NAV_LINKS } from "@/components/Home/nav-links";
 import { render,within } from "@testing-library/react";
 import {  beforeEach, describe, expect, it, vi } from "vitest";
 import * as Query from '@tanstack/react-query';


### PR DESCRIPTION
## O que
Move a constante `NAV_LINKS` de `Header.tsx` para um novo arquivo `nav-links.ts`.

## Por quê
O job `Lint & Build` estava falhando na PR #193 (e segue quebrando no `development`) por causa da regra `react-refresh/only-export-components` do ESLint: arquivos de componente React não podem exportar outras coisas além de componentes, pois isso quebra o Fast Refresh. `Header.tsx` exportava `NAV_LINKS` junto do componente `Header`.

## Mudanças
- Nova constante em `frontend/src/components/Home/nav-links.ts`
- `Header.tsx` importa `NAV_LINKS` do novo arquivo
- Teste (`Header.test.tsx`) ajustado para importar `NAV_LINKS` do novo local

## Teste
- `npm run lint` limpo
- `npm test` — 12 arquivos / 29 testes passando