### PR TITLE
fix: liga tela de confirmacao do curriculo no fluxo real (#106)

### DIFF
--- a/frontend/src/components/Home/ResumeCard.tsx
+++ b/frontend/src/components/Home/ResumeCard.tsx
@@ -1,4 +1,4 @@
-import { ChartSpline, Clock, Download, FileText, Trash2, Zap } from "lucide-react";
+import { ChartSpline, CheckCircle2, Clock, Download, FileText, Trash2, Zap } from "lucide-react";
 
 export interface ResumeCardProps {
   fileName: string;
@@ -6,8 +6,10 @@ export interface ResumeCardProps {
   updatedLabel: string;
   tags: string[];
   maxVisibleTags?: number;
+  status?: string;
   onDownload?: () => void;
   onMatch?: () => void;
+  onReview?: () => void;
   onDelete?: () => void;
 }
 
@@ -17,10 +19,13 @@ export default function ResumeCard({
   updatedLabel,
   tags,
   maxVisibleTags = 3,
+  status,
   onDownload,
   onMatch,
+  onReview,
   onDelete,
 }: ResumeCardProps) {
+  const needsReview = status === "analyze" && !!onReview;
   const visibleTags = tags.slice(0, maxVisibleTags);
   const hiddenCount = tags.length - visibleTags.length;
 
@@ -68,14 +73,25 @@ export default function ResumeCard({
           <Download className="size-5" aria-hidden="true" />
           Baixar
         </button>
-        <button
-          type="button"
-          onClick={onMatch}
-          className="flex cursor-pointer flex-col items-center gap-1.5 rounded-lg py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-brand-primary"
-        >
-          <ChartSpline className="size-5" aria-hidden="true" />
-          Match
-        </button>
+        {needsReview ? (
+          <button
+            type="button"
+            onClick={onReview}
+            className="flex cursor-pointer flex-col items-center gap-1.5 rounded-lg py-1.5 text-xs font-medium text-brand-primary transition-colors hover:bg-brand-primary/10"
+          >
+            <CheckCircle2 className="size-5" aria-hidden="true" />
+            Confirmar
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onMatch}
+            className="flex cursor-pointer flex-col items-center gap-1.5 rounded-lg py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-brand-primary"
+          >
+            <ChartSpline className="size-5" aria-hidden="true" />
+            Match
+          </button>
+        )}
         <button
           type="button"
           onClick={onDelete}

--- a/frontend/src/components/Home/ResumeList.tsx
+++ b/frontend/src/components/Home/ResumeList.tsx
@@ -7,6 +7,7 @@ interface ResumeListProps {
   onDeleteResume?: (id: string) => void;
   onDownloadResume?: (id: string) => void;
   onFinalizeResume?: (id: string) => void;
+  onReviewResume?: (id: string) => void;
 }
 
 export default function ResumeList({
@@ -15,6 +16,7 @@ export default function ResumeList({
   onDeleteResume,
   onDownloadResume,
   onFinalizeResume,
+  onReviewResume,
 }: ResumeListProps) {
   return (
     <section aria-label="Lista de currículos" className="mt-6 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
@@ -28,6 +30,9 @@ export default function ResumeList({
           }
           onMatch={
             onFinalizeResume ? () => onFinalizeResume(id) : card.onMatch
+          }
+          onReview={
+            onReviewResume ? () => onReviewResume(id) : card.onReview
           }
         />
       ))}

--- a/frontend/src/components/resume-upload/ResumeReviewStage.tsx
+++ b/frontend/src/components/resume-upload/ResumeReviewStage.tsx
@@ -17,9 +17,10 @@ export interface ReviewSection {
 interface ResumeReviewStageProps {
   sections: ReviewSection[];
   onGenerate: (selectedItemIds: string[]) => void;
+  isSubmitting?: boolean;
 }
 
-export function ResumeReviewStage({ sections, onGenerate }: ResumeReviewStageProps) {
+export function ResumeReviewStage({ sections, onGenerate, isSubmitting = false }: ResumeReviewStageProps) {
   const allItemIds = sections.flatMap((section) => section.items.map((item) => item.id));
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set(allItemIds));
 
@@ -73,8 +74,13 @@ export function ResumeReviewStage({ sections, onGenerate }: ResumeReviewStagePro
           ))}
         </div>
 
-        <Button className="mt-6 w-full" size="lg" onClick={() => onGenerate(Array.from(checkedIds))}>
-          Gerar currículo
+        <Button
+          className="mt-6 w-full"
+          size="lg"
+          disabled={isSubmitting}
+          onClick={() => onGenerate(Array.from(checkedIds))}
+        >
+          {isSubmitting ? "Gerando..." : "Gerar currículo"}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/resume-upload/resume-analytic-adapter.test.ts
+++ b/frontend/src/components/resume-upload/resume-analytic-adapter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { reviewSectionsFromAnalytic, filterAnalyticBySelection } from "@/components/resume-upload/resume-analytic-adapter";
+import type { ResumeAnalytic } from "@/types/resume";
+
+const analytic: ResumeAnalytic = {
+  id: 1,
+  analysis_request_id: null,
+  user_id: 1,
+  user_resume_id: "resume-uuid",
+  status: "analyze",
+  error: null,
+  header: { name: "Pedro Aruanã" },
+  experiences: [
+    { company: "WhiteHats", role: "Dev", start: "2023-01", end: "2026-01", is_actual: false },
+    { company: "Bom Currículo", role: "Voluntário", start: "2025-01", end: null, is_actual: true },
+  ],
+  qualifications: [
+    { type: "higher_education", institution: "Uniasselvi", title: "Ciência da Computação" },
+  ],
+  skills: [
+    { name: "PHP", years: 5 },
+    { name: "React", years: 2 },
+  ],
+  languages: [{ language: "Inglês", level: "advanced" }],
+  projects: [],
+  others: { score: 85 },
+  created_at: "2026-01-01",
+  updated_at: "2026-01-01",
+};
+
+describe("reviewSectionsFromAnalytic", () => {
+  it("builds one section per non-empty category, skipping empty ones", () => {
+    const sections = reviewSectionsFromAnalytic(analytic);
+    const ids = sections.map((section) => section.id);
+
+    expect(ids).toEqual(["experiences", "qualifications", "skills", "languages"]);
+  });
+
+  it("labels each item with the source's fields", () => {
+    const [experiencesSection] = reviewSectionsFromAnalytic(analytic);
+
+    expect(experiencesSection.items[0]).toEqual({
+      id: "experience-0",
+      title: "Dev — WhiteHats",
+      description: "2023-01 até 2026-01",
+    });
+    expect(experiencesSection.items[1].description).toBe("2025-01 até atual");
+  });
+});
+
+describe("filterAnalyticBySelection", () => {
+  it("keeps only the selected entries in each array", () => {
+    const filtered = filterAnalyticBySelection(analytic, ["experience-1", "skill-0"]);
+
+    expect(filtered.experiences).toHaveLength(1);
+    expect(filtered.experiences[0].company).toBe("Bom Currículo");
+    expect(filtered.skills).toHaveLength(1);
+    expect(filtered.skills[0].name).toBe("PHP");
+    expect(filtered.qualifications).toHaveLength(0);
+    expect(filtered.languages).toHaveLength(0);
+  });
+
+  it("always passes header and others through untouched", () => {
+    const filtered = filterAnalyticBySelection(analytic, []);
+
+    expect(filtered.header).toEqual({ name: "Pedro Aruanã" });
+    expect(filtered.others).toEqual({ score: 85 });
+  });
+});

--- a/frontend/src/components/resume-upload/resume-analytic-adapter.ts
+++ b/frontend/src/components/resume-upload/resume-analytic-adapter.ts
@@ -1,0 +1,91 @@
+import type { ResumeAnalytic } from "@/types/resume";
+import type { ReviewSection } from "@/components/resume-upload/ResumeReviewStage";
+
+/** Turns the AI-analyzed data into the generic sections the checkbox UI renders. */
+export function reviewSectionsFromAnalytic(analytic: ResumeAnalytic): ReviewSection[] {
+  const sections: ReviewSection[] = [];
+
+  if (analytic.experiences?.length) {
+    sections.push({
+      id: "experiences",
+      title: "Experiências",
+      items: analytic.experiences.map((experience, index) => ({
+        id: `experience-${index}`,
+        title: `${experience.role} — ${experience.company}`,
+        description: [experience.start, experience.is_actual ? "atual" : experience.end]
+          .filter(Boolean)
+          .join(" até "),
+      })),
+    });
+  }
+
+  if (analytic.qualifications?.length) {
+    sections.push({
+      id: "qualifications",
+      title: "Cursos e formação",
+      items: analytic.qualifications.map((qualification, index) => ({
+        id: `qualification-${index}`,
+        title: qualification.title,
+        description: qualification.institution,
+      })),
+    });
+  }
+
+  if (analytic.skills?.length) {
+    sections.push({
+      id: "skills",
+      title: "Habilidades",
+      items: analytic.skills.map((skill, index) => ({
+        id: `skill-${index}`,
+        title: skill.name,
+        description: skill.years ? `${skill.years} anos de experiência` : undefined,
+      })),
+    });
+  }
+
+  if (analytic.languages?.length) {
+    sections.push({
+      id: "languages",
+      title: "Idiomas",
+      items: analytic.languages.map((language, index) => ({
+        id: `language-${index}`,
+        title: language.language,
+        description: language.level,
+      })),
+    });
+  }
+
+  if (analytic.projects?.length) {
+    sections.push({
+      id: "projects",
+      title: "Projetos",
+      items: analytic.projects.map((project, index) => ({
+        id: `project-${index}`,
+        title: project.title,
+        description: project.description ?? undefined,
+      })),
+    });
+  }
+
+  return sections;
+}
+
+/**
+ * Rebuilds the finish-resume payload's arrays, keeping only the entries whose
+ * generated id (see reviewSectionsFromAnalytic) is in selectedItemIds.
+ */
+export function filterAnalyticBySelection(analytic: ResumeAnalytic, selectedItemIds: string[]) {
+  const selected = new Set(selectedItemIds);
+  const keep = <T,>(items: T[] | undefined, prefix: string): T[] =>
+    (items ?? []).filter((_, index) => selected.has(`${prefix}-${index}`));
+
+  return {
+    header: analytic.header ?? {},
+    experiences: keep(analytic.experiences, "experience"),
+    qualifications: keep(analytic.qualifications, "qualification"),
+    skills: keep(analytic.skills, "skill"),
+    languages: keep(analytic.languages, "language"),
+    projects: keep(analytic.projects, "project"),
+    others: analytic.others ?? {},
+  };
+}

--- a/frontend/src/hooks/use-user-resumes.ts
+++ b/frontend/src/hooks/use-user-resumes.ts
@@ -5,6 +5,7 @@ import type { UserResume, ResumeAnalytic } from "@/types/resume";
 
 export interface DashboardResume {
   id: string;
+  analyticId: number | null;
   fileName: string;
   matchPercentage: number;
   updatedLabel: string;
@@ -78,6 +79,7 @@ function combine(
 
     return {
       id: resume.id,
+      analyticId: analytic?.id ?? null,
       fileName: fileNameFromResume(resume),
       matchPercentage: analyticScore(analytic),
       updatedLabel: relativeTime(resume.updated_at),

--- a/frontend/src/pages/dashboard/resumes/ConfirmResume.tsx
+++ b/frontend/src/pages/dashboard/resumes/ConfirmResume.tsx
@@ -1,0 +1,64 @@
+import { useNavigate, useParams } from "react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Header } from "@/components/Home/Header";
+import { ResumeReviewStage } from "@/components/resume-upload/ResumeReviewStage";
+import {
+  reviewSectionsFromAnalytic,
+  filterAnalyticBySelection,
+} from "@/components/resume-upload/resume-analytic-adapter";
+import { getResumeAnalytic, finishResume } from "@/api/resume";
+import { getApiErrorMessage } from "@/api/client";
+
+export default function ConfirmResume() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const analyticQuery = useQuery({
+    queryKey: ["resume", "analytic", id],
+    queryFn: () => getResumeAnalytic(id!),
+    enabled: !!id,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (selectedItemIds: string[]) => {
+      const analytic = analyticQuery.data!;
+      const filtered = filterAnalyticBySelection(analytic, selectedItemIds);
+      return finishResume({
+        user_resume_id: analytic.user_resume_id!,
+        ...filtered,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user", "resumes"] });
+      queryClient.invalidateQueries({ queryKey: ["resumes", "pendings"] });
+      toast.success("Currículo gerado com sucesso!");
+      navigate("/meus-curriculos");
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, "Erro ao gerar o currículo. Tente novamente."));
+    },
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <div className="flex flex-1 flex-col p-6">
+        {analyticQuery.isLoading ? (
+          <p className="text-center text-sm text-muted-foreground">Carregando dados analisados...</p>
+        ) : analyticQuery.isError || !analyticQuery.data ? (
+          <p className="text-center text-sm text-destructive">
+            Não foi possível carregar a análise desse currículo.
+          </p>
+        ) : (
+          <ResumeReviewStage
+            sections={reviewSectionsFromAnalytic(analyticQuery.data)}
+            onGenerate={(selectedItemIds) => mutation.mutate(selectedItemIds)}
+            isSubmitting={mutation.isPending}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/resumes/MyResumes.tsx
+++ b/frontend/src/pages/dashboard/resumes/MyResumes.tsx
@@ -37,6 +37,12 @@ export default function MyResumes() {
                   window.open(url, "_blank");
                 }
               }}
+              onReviewResume={(id) => {
+                const resume = resumes.find((item) => item.id === id);
+                if (resume?.analyticId != null) {
+                  navigate(`/meus-curriculos/${resume.analyticId}/confirmar`);
+                }
+              }}
             />
           </>
         ) : (

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -17,6 +17,7 @@ import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import Home from "@/pages/dashboard/home/Home";
 import MyResumes from "@/pages/dashboard/resumes/MyResumes";
 import NewResume from "@/pages/dashboard/resumes/NewResume";
+import ConfirmResume from "@/pages/dashboard/resumes/ConfirmResume";
 
 // ???
 //import Editor from "@/pages/dashboard/editor/Editor";
@@ -44,6 +45,7 @@ export function AppRoutes() {
           {/* Pages */}
           <Route path="/" element={<Home />} />
           <Route path="/meus-curriculos" element={<MyResumes />} />
+          <Route path="/meus-curriculos/:id/confirmar" element={<ConfirmResume />} />
           <Route path="/novo-curriculo" element={<NewResume />} />
 
           {/* ???


### PR DESCRIPTION
## Description

Issue #106 estava com a tela de confirmação pronta mas sem estar ligada em lugar nenhum do fluxo, depois da reestruturação do front. Criei a página de confirmação e liguei ela no card do currículo: quando o status é "análise", aparece um botão "Confirmar" que abre a tela com os dados reais da API, deixando desmarcar itens antes de gerar o currículo final.

## AI Usage

* [ ] Vibe coding
* [ ] Research

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area

* [x] Frontend
* [ ] Backend
* [ ] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [x] Added/updated tests when necessary
* [ ] Updated the documentation when necessary

## How to test

1. Fazer login e ter um currículo com status "Em análise"
2. Na tela "Meus Currículos", clicar em "Confirmar" no card do currículo
3. Verificar que a tela carrega os dados reais da análise (experiências, formação, habilidades, idiomas)
4. Desmarcar algum item e clicar em "Gerar currículo"
5. Confirmar que volta pra "Meus Currículos" com o currículo pronto pra baixar
<img width="1536" height="750" alt="image" src="https://github.com/user-attachments/assets/f0d1d70d-8fd9-4f85-84ef-9a8a857414bb" />
