### PR TITLE
fix: leva direto pra confirmacao apos analise e corrige id da rota (#…

### DIFF
--- a/frontend/src/hooks/use-user-resumes.ts
+++ b/frontend/src/hooks/use-user-resumes.ts
@@ -5,7 +5,6 @@ import type { UserResume, ResumeAnalytic } from "@/types/resume";
 
 export interface DashboardResume {
   id: string;
-  analyticId: number | null;
   fileName: string;
   matchPercentage: number;
   updatedLabel: string;
@@ -79,7 +78,6 @@ function combine(
 
     return {
       id: resume.id,
-      analyticId: analytic?.id ?? null,
       fileName: fileNameFromResume(resume),
       matchPercentage: analyticScore(analytic),
       updatedLabel: relativeTime(resume.updated_at),

--- a/frontend/src/pages/dashboard/resumes/ConfirmResume.tsx
+++ b/frontend/src/pages/dashboard/resumes/ConfirmResume.tsx
@@ -7,7 +7,7 @@ import {
   reviewSectionsFromAnalytic,
   filterAnalyticBySelection,
 } from "@/components/resume-upload/resume-analytic-adapter";
-import { getResumeAnalytic, finishResume } from "@/api/resume";
+import { listResumeAnalytics, finishResume } from "@/api/resume";
 import { getApiErrorMessage } from "@/api/client";
 
 export default function ConfirmResume() {
@@ -15,15 +15,17 @@ export default function ConfirmResume() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const analyticQuery = useQuery({
-    queryKey: ["resume", "analytic", id],
-    queryFn: () => getResumeAnalytic(id!),
+  const analyticsQuery = useQuery({
+    queryKey: ["resumes", "pendings"],
+    queryFn: listResumeAnalytics,
     enabled: !!id,
   });
 
+  const analytic = analyticsQuery.data?.find((item) => item.user_resume_id === id);
+
   const mutation = useMutation({
     mutationFn: (selectedItemIds: string[]) => {
-      const analytic = analyticQuery.data!;
+      if (!analytic) throw new Error("Análise não encontrada.");
       const filtered = filterAnalyticBySelection(analytic, selectedItemIds);
       return finishResume({
         user_resume_id: analytic.user_resume_id!,
@@ -45,15 +47,15 @@ export default function ConfirmResume() {
     <div className="flex min-h-screen flex-col">
       <Header />
       <div className="flex flex-1 flex-col p-6">
-        {analyticQuery.isLoading ? (
+        {analyticsQuery.isLoading ? (
           <p className="text-center text-sm text-muted-foreground">Carregando dados analisados...</p>
-        ) : analyticQuery.isError || !analyticQuery.data ? (
+        ) : analyticsQuery.isError || !analytic ? (
           <p className="text-center text-sm text-destructive">
             Não foi possível carregar a análise desse currículo.
           </p>
         ) : (
           <ResumeReviewStage
-            sections={reviewSectionsFromAnalytic(analyticQuery.data)}
+            sections={reviewSectionsFromAnalytic(analytic)}
             onGenerate={(selectedItemIds) => mutation.mutate(selectedItemIds)}
             isSubmitting={mutation.isPending}
           />

--- a/frontend/src/pages/dashboard/resumes/MyResumes.tsx
+++ b/frontend/src/pages/dashboard/resumes/MyResumes.tsx
@@ -37,12 +37,7 @@ export default function MyResumes() {
                   window.open(url, "_blank");
                 }
               }}
-              onReviewResume={(id) => {
-                const resume = resumes.find((item) => item.id === id);
-                if (resume?.analyticId != null) {
-                  navigate(`/meus-curriculos/${resume.analyticId}/confirmar`);
-                }
-              }}
+              onReviewResume={(id) => navigate(`/meus-curriculos/${id}/confirmar`)}
             />
           </>
         ) : (

--- a/frontend/src/pages/dashboard/resumes/NewResume.tsx
+++ b/frontend/src/pages/dashboard/resumes/NewResume.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { createResume, analyseResume, listUserResumes } from "@/api/resume";
 import type { CreateResumeSkill } from "@/api/resume";
@@ -13,7 +14,6 @@ import {
   Plus,
   Trash2,
   Send,
-  CheckCircle2,
   AlertCircle,
 } from 'lucide-react';
 
@@ -21,6 +21,7 @@ export type Skill = CreateResumeSkill;
 
 export default function NewResume() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [resumePdf, setResumePdf] = useState<File | null>(null);
   const [linkedinPdf, setLinkedinPdf] = useState<File | null>(null);
   const [githubUrl, setGithubUrl] = useState<string>('');
@@ -31,38 +32,30 @@ export default function NewResume() {
   const [currentYears, setCurrentYears] = useState<string>('');
 
   const mutation = useMutation({
-    mutationFn: () =>
-      createResume({
+    mutationFn: async () => {
+      await createResume({
         resume_cv: resumePdf,
         resume_linkedin: linkedinPdf,
         github_link: githubUrl,
         site_link: portfolioUrl,
         skills,
-      }),
-    onSuccess: async () => {
-      queryClient.invalidateQueries({ queryKey: ["user", "resumes"] });
-      queryClient.invalidateQueries({ queryKey: ["resumes", "pendings"] });
+      });
 
-      try {
-        const resumes = await listUserResumes();
-        const newest = resumes[0];
-        if (newest) {
-          void analyseResume(newest.id).catch(() => {
-            /* análise disparada de forma assíncrona */
-          });
-        }
-      } catch {
-        /* o currículo já foi salvo; análise será integrada quando disponível */
+      const resumes = await listUserResumes();
+      const newest = resumes[0];
+      if (!newest) {
+        throw new Error('Não foi possível localizar o currículo enviado.');
       }
 
-      queryClient.invalidateQueries({ queryKey: ["user", "resumes"] });
+      await analyseResume(newest.id);
 
-      toast.success('Dados enviados com sucesso! A IA está processando o currículo.');
-      setResumePdf(null);
-      setLinkedinPdf(null);
-      setGithubUrl('');
-      setPortfolioUrl('');
-      setSkills([]);
+      return newest.id;
+    },
+    onSuccess: (resumeId) => {
+      queryClient.invalidateQueries({ queryKey: ["user", "resumes"] });
+      queryClient.invalidateQueries({ queryKey: ["resumes", "pendings"] });
+      toast.success('Currículo analisado! Confirme os dados.');
+      navigate(`/meus-curriculos/${resumeId}/confirmar`);
     },
     onError: (error) => {
       toast.error(getApiErrorMessage(error, 'Erro ao conectar com o servidor. Tente novamente.'));
@@ -262,13 +255,6 @@ export default function NewResume() {
           </div>
         )}
 
-        {mutation.isSuccess && (
-          <div className="mt-4 flex items-center gap-2 rounded-lg bg-green-50 px-4 py-3 text-sm text-green-800">
-            <CheckCircle2 size={20} />
-            <span>Dados enviados com sucesso! A IA está processando o currículo.</span>
-          </div>
-        )}
-
         <div className="mt-6 flex justify-end">
           <button
             type="submit"
@@ -276,7 +262,7 @@ export default function NewResume() {
             className="flex items-center gap-2 rounded-[10px] bg-[#031b5b] px-7 py-3.5 text-[15px] font-semibold text-white shadow-[0_4px_12px_rgba(3,7,18,0.15)] disabled:cursor-not-allowed disabled:opacity-70"
           >
             <Send size={18} />
-            <span>{mutation.isPending ? 'Processando dados...' : 'Gerar Currículo com IA'}</span>
+            <span>{mutation.isPending ? 'Analisando com IA...' : 'Gerar Currículo com IA'}</span>
           </button>
         </div>
 


### PR DESCRIPTION
…106)

## Description

O PR anterior (#247) já tinha sido mergeado, mas o Flávio apontou dois problemas depois de testar: a URL usava o id interno da análise em vez do id do currículo, e o fluxo não caía direto na tela de confirmar depois do upload.

Ajustei os dois: agora a tela de confirmar resolve o currículo pelo id (uuid) da URL, e assim que a análise da IA termina, o usuário já cai direto nela, sem precisar voltar pra lista e clicar em "Confirmar" separado.

## AI Usage

* [ ] Vibe coding
* [ ] Research

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area

* [x] Frontend
* [ ] Backend
* [ ] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [ ] Added/updated tests when necessary
* [ ] Updated the documentation when necessary

## How to test

1. Fazer login e ir em "Novo Currículo"
2. Anexar um PDF e clicar em "Gerar Currículo com IA"
3. Confirmar que, ao terminar a análise, cai direto na tela "Confirme seus dados" (sem passar pela lista)
4. Reparar que a URL usa o id do currículo, não um número solto
<img width="1536" height="800" alt="image" src="https://github.com/user-attachments/assets/25d74d74-27f8-457f-8b99-8e980d736d07" />
