### PR TITLE
fix(mobile): allow cleartext in debug, per-dev API URL via .env and use ApiConfig in API

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,14 @@
+# Environment Variables for Bom Currículo
+# Copie este arquivo para .env e ajuste os valores conforme necessário
+
+# URL da API para desenvolvimento em dispositivo físico (use seu IP)
+API_URL_DEV_PHYSICAL=http://192.168.1.100:9000
+
+# URL da API para produção
+API_URL_PROD=https://api.bomcurriculo.com
+
+# URL alternativa para emuladores Android (10.0.2.2 acessa o host)
+API_URL_ANDROID_EMULATOR=http://10.0.2.2:3000
+
+# URL alternativa para emuladores iOS
+API_URL_IOS_EMULATOR=http://localhost:3000

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,6 +1,30 @@
-# Bom Currículo Mobile - Em construção
+# Bom Currículo Mobile
 
 Site: https://bomcurriculo.tech
+
+## Configuração de ambiente
+
+O app usa `.env` para definir a URL da API por tipo de dispositivo. O arquivo `.env` está no `.gitignore`, cada desenvolvedor mantém seu próprio.
+
+Copie o exemplo:
+```bash
+cp .env.example .env
+```
+
+Variáveis principais:
+- `API_URL_DEV_PHYSICAL` - IP da máquina onde o backend roda, ex: `http://192.168.1.100:9000`. Use seu IP local para testar no celular físico.
+- `API_URL_PROD` - URL de produção.
+- `API_URL_ANDROID_EMULATOR` - `http://10.0.2.2:9000` para emulador Android.
+- `API_URL_IOS_EMULATOR` - `http://localhost:9000` para simulador iOS.
+
+O app também aceita override via dart-define:
+```bash
+flutter run --dart-define=API_URL=http://192.168.X.X:9000
+```
+
+### Cleartext HTTP em desenvolvimento
+
+Para builds de debug o Android permite tráfego HTTP local via `android/app/src/main/res/xml/network_security_config.xml`. Em release o cleartext é bloqueado e só HTTPS é permitido.
 
 Views:
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <application
         android:label="Bom Currículo"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Produção: cleartext desabilitado por padrão -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Debug: permitir cleartext e certs do usuário em builds de debug -->
+    <debug-overrides>
+        <base-config cleartextTrafficPermitted="true">
+            <trust-anchors>
+                <certificates src="system" />
+                <certificates src="user" />
+            </trust-anchors>
+        </base-config>
+    </debug-overrides>
+
+
+</network-security-config>

--- a/mobile/lib/config/api_config.dart
+++ b/mobile/lib/config/api_config.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:bomcurriculo/config/environment.dart';
+
+class ApiConfig {
+  static String get baseUrl {
+    // 1. PRIORIDADE MÁXIMA: --dart-define=API_URL=...
+    // Verifica se foi passado via ambiente Dart
+    final dartDefineUrl = String.fromEnvironment('API_URL', defaultValue: '');
+    if (dartDefineUrl.isNotEmpty) {
+      return dartDefineUrl;
+    }
+
+    // 2. Produção
+    if (Environment.isProduction) {
+      final prodUrl = dotenv.env['API_URL_PROD'];
+      if (prodUrl != null && prodUrl.isNotEmpty) {
+        return prodUrl;
+      }
+      return 'https://api.bomcurriculo.com'; // fallback produção
+    }
+
+    // 4. Desenvolvimento - verificar dispositivo físico vs emulador
+    if (Environment.isPhysicalDevice) {
+      // Dispositivo físico: usar IP configurado via .env
+      final physicalUrl = dotenv.env['API_URL_DEV_PHYSICAL'];
+      if (physicalUrl != null && physicalUrl.isNotEmpty) {
+        return physicalUrl;
+      }
+      // Fallback se .env não tiver o IP
+      return 'http://192.168.31.137:9000';
+    }
+
+    // 5. Emulador Android
+    if (kIsWeb || !Environment.isPhysicalDevice && defaultTargetPlatform == TargetPlatform.android) {
+      final androidUrl = dotenv.env['API_URL_ANDROID_EMULATOR'];
+      if (androidUrl != null && androidUrl.isNotEmpty) {
+        return androidUrl;
+      }
+      return 'http://10.0.2.2:3000';
+    }
+
+    // 6. Emulador iOS
+    if (defaultTargetPlatform == TargetPlatform.iOS && !Environment.isPhysicalDevice) {
+      final iosUrl = dotenv.env['API_URL_IOS_EMULATOR'];
+      if (iosUrl != null && iosUrl.isNotEmpty) {
+        return iosUrl;
+      }
+      return 'http://localhost:3000';
+    }
+
+    // 6. Fallback final
+    return 'http://localhost:3000';
+  }
+
+  static String get debugInfo {
+    final envStatus = dotenv.env.isNotEmpty ? '✅ Carregado' : '❌ Não carregado';
+
+    return '''🌍 AMBIENTE: ${Environment.environment.name}
+📱 FÍSICO: ${Environment.isPhysicalDevice ? 'true' : 'false'}
+🔗 URL: $baseUrl
+📄 .env: $envStatus''';
+  }
+}

--- a/mobile/lib/service/API.dart
+++ b/mobile/lib/service/API.dart
@@ -5,10 +5,12 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
-import '../config.dart';
+import '../config/api_config.dart';
 import 'DB.dart';
 
 class API {
+  String get _baseUrl => '${ApiConfig.baseUrl}/api/';
+
   Future<Map<String, String>> _headers() async {
     final headers = <String, String>{
       "Content-Type": "application/json",
@@ -23,14 +25,16 @@ class API {
   }
 
   Future get(String url) async {
+    final fullUrl = "$_baseUrl$url";
     try {
       final response = await http.get(
-        Uri.parse("$baseURL$url"),
+        Uri.parse(fullUrl),
         headers: await _headers(),
-      );
+      ).timeout(const Duration(seconds: 8));
       debugPrint("Response: ${response.body}");
       return response;
     } catch (e) {
+      debugPrint('GET $url error: $e');
       return {"error": e.toString()};
     }
   }
@@ -38,7 +42,7 @@ class API {
   Future post(String url, Map<String, dynamic> data) async {
     try {
       final response = await http.post(
-        Uri.parse("$baseURL$url"),
+        Uri.parse("$_baseUrl$url"),
         headers: await _headers(),
         body: jsonEncode(data),
       );
@@ -52,7 +56,7 @@ class API {
   Future put(String url, Map<String, dynamic> data) async {
     try {
       final response = await http.put(
-        Uri.parse("$baseURL$url"),
+        Uri.parse("$_baseUrl$url"),
         headers: await _headers(),
         body: jsonEncode(data),
       );
@@ -66,7 +70,7 @@ class API {
   Future patch(String url, Map<String, dynamic> data) async {
     try {
       final response = await http.patch(
-        Uri.parse("$baseURL$url"),
+        Uri.parse("$_baseUrl$url"),
         headers: await _headers(),
         body: jsonEncode(data),
       );
@@ -80,7 +84,7 @@ class API {
   Future delete(String url) async {
     try {
       final response = await http.delete(
-        Uri.parse("$baseURL$url"),
+        Uri.parse("$_baseUrl$url"),
         headers: await _headers(),
       );
       debugPrint("Response: ${response.body}");
@@ -96,7 +100,7 @@ class API {
     List<Map<String, String>> files,
   ) async {
     try {
-      final request = http.MultipartRequest("POST", Uri.parse("$baseURL$url"));
+      final request = http.MultipartRequest("POST", Uri.parse("$_baseUrl$url"));
 
       final headers = await _headers();
       headers.remove("Content-Type");


### PR DESCRIPTION
## Description
API now uses ApiConfig.baseUrl from .env. Fixes timeout on physical device because API.dart was using a hardcoded baseURL for 10.0.2.2.

## AI Usage
* [x] Vibe coding
* [x] Research

## Type of change
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area
* [ ] Frontend
* [ ] Backend
* [x] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist
* [x] Tested locally
* [ ] Added/updated tests when necessary
* [ ] Updated the documentation when necessary

## How to test
1. Set API_URL_DEV_PHYSICAL in .env
2. Run `flutter run -d <device>`
3. Verify logs show GET http://<IP>:9000/api/client/user without timeout