### PR TITLE
fix(resume): handle bot failures without persisting mock data

### DIFF
--- a/backend/app/Http/ApiRequests/Client/Resume/NewResumeRequest.php
+++ b/backend/app/Http/ApiRequests/Client/Resume/NewResumeRequest.php
@@ -9,8 +9,8 @@ class NewResumeRequest extends CustomRequest
     public function rules(): array
     {
         return [
-            'resume_cv' => ['required', 'file', 'mimes:pdf,doc,docx', 'min:5', 'max:10240'],
-            'resume_linkedin' => ['file', 'mimes:pdf,doc,docx', 'min:5', 'max:10240'],
+            'resume_cv' => ['required', 'file', 'mimes:pdf,docx', 'min:5', 'max:10240'],
+            'resume_linkedin' => ['file', 'mimes:pdf', 'min:5', 'max:10240'],
             'github_link' => ['nullable', 'string', 'min:9', 'max:255'],
             'site_link' => ['nullable', 'string', 'min:9', 'max:255'],
             'skills' => ['nullable', 'array'],

--- a/backend/app/Http/Controllers/Api/Resume/ResumeController.php
+++ b/backend/app/Http/Controllers/Api/Resume/ResumeController.php
@@ -35,8 +35,8 @@ class ResumeController extends Controller
                 mediaType: 'multipart/form-data',
                 schema: new OA\Schema(
                     properties: [
-                        new OA\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
-                        new OA\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'PDF/DOC/DOCX, até 10MB'),
+                        new OA\Property(property: 'resume_cv', type: 'string', format: 'binary', description: 'PDF/DOCX, até 10MB'),
+                        new OA\Property(property: 'resume_linkedin', type: 'string', format: 'binary', description: 'PDF, até 10MB'),
                         new OA\Property(property: 'github_link', type: 'string', nullable: true),
                         new OA\Property(property: 'site_link', type: 'string', nullable: true),
                         new OA\Property(

--- a/backend/app/Services/Bot/Actions/ProcessBotAction.php
+++ b/backend/app/Services/Bot/Actions/ProcessBotAction.php
@@ -35,6 +35,7 @@ class ProcessBotAction
                 // Atualiza o status da análise do currículo
                 $resume->update([
                     'status' => UserResumeEnum::ANALYZE,
+                    'observation' => null,
                 ]);
 
                 // Cria ou atualiza a análise do currículo

--- a/backend/app/Services/Bot/Actions/PublishBotAction.php
+++ b/backend/app/Services/Bot/Actions/PublishBotAction.php
@@ -4,9 +4,11 @@ namespace App\Services\Bot\Actions;
 
 use App\Models\User;
 use App\Models\UserResume;
-use Exception;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Storage;
+use JsonException;
+use RuntimeException;
 
 class PublishBotAction
 {
@@ -14,192 +16,104 @@ class PublishBotAction
 
     private static User $user;
 
-    private static UserResume|array $resume;
+    private static UserResume $resume;
 
     public function __construct(
         $http,
         User $user,
-        UserResume|array $resume
+        UserResume $resume
     ) {
         self::$http = $http;
         self::$user = $user;
         self::$resume = $resume;
     }
 
-    public static function handle()
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws RequestException
+     * @throws JsonException
+     */
+    public static function handle(): array
     {
+        $bot = self::build(self::$resume, self::$user);
+
+        if (! $bot->successful()) {
+            throw new RequestException($bot);
+        }
+
+        $data = $bot->json();
+
+        if (! is_array($data)) {
+            throw new RuntimeException('Bot returned an invalid response.', 502);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private static function build(UserResume $resume, User $user): Response
+    {
+        $cvPath = $resume->original_file_path_cv;
+
+        if (empty($cvPath) || ! Storage::exists($cvPath)) {
+            throw new RuntimeException('Resume CV file is missing.', 422);
+        }
+
+        $cvStream = Storage::readStream($cvPath);
+
+        if (! is_resource($cvStream)) {
+            throw new RuntimeException('Resume CV file could not be opened.', 500);
+        }
+
+        $linkedinStream = null;
+        $linkedinPath = $resume->original_file_path_linkedin;
+
         try {
-
-            $resume = UserResume::find(self::$resume['id']);
-
-            $user = self::$user;
-            $bot = self::build($resume, $user);
-
-            if ($bot->getStatusCode() !== 200) {
-                // throw new Exception($bot->json()->detail, $bot->getStatusCode());
-
-                // TODO: Remove all overflow validated
-                return self::mockData();
-            }
-
-            return $bot->json();
-
-        } catch (RequestException $exception) {
-            $statusCode = $exception->response->status();
-            throw new Exception($exception->getMessage(), $statusCode, $exception);
-        } catch (Exception $exception) {
-            throw new Exception($exception->getMessage(), $exception->getCode(), $exception);
-        }
-    }
-
-    private static function build($resume, $user)
-    {
-        $payload = self::dataToBot($resume, $user);
-
-        if (isset($payload['resume_cv_stream']) && is_resource($payload['resume_cv_stream'])) {
-            return self::$http->attach(
+            $request = self::$http->attach(
                 'resume_cv',
-                $payload['resume_cv_stream'],
-                $payload['resume_cv_filename']
-            )->post('/build', [
-                'additional_skills' => json_encode($payload['additional_skills']),
-                'github_url' => $payload['github_url'],
-                'portfolio_url' => $payload['portfolio_url'],
-                'resume_linkedin' => $payload['resume_linkedin'],
-            ]); // ->throw();
-        }
+                $cvStream,
+                basename($cvPath)
+            );
 
-        return self::$http->post('/build', $payload);
-    }
+            if (! empty($linkedinPath) && Storage::exists($linkedinPath)) {
+                $linkedinStream = Storage::readStream($linkedinPath);
 
-    private static function dataToBot($userResume, $user)
-    {
-        $expires_link = now()->addDay();
-        $resume_cv_stream = null;
-        $resume_cv_filename = 'resume.pdf';
-        $resume_linkedin = null;
+                if (! is_resource($linkedinStream)) {
+                    throw new RuntimeException('LinkedIn resume file could not be opened.', 500);
+                }
 
-        $cv_path = null;
-        if ($userResume && $userResume->id !== null) {
-            $cv_path = $userResume->original_file_path_cv;
-            if (! empty($userResume->original_file_path_linkedin)) {
-                $resume_linkedin = Storage::temporaryUrl($userResume->original_file_path_linkedin, $expires_link);
+                $request = $request->attach(
+                    'resume_linkedin',
+                    $linkedinStream,
+                    basename($linkedinPath)
+                );
             }
-        } else {
-            $cv_path = $user->resume_cv;
-            if (! empty($user->resume_linkedin)) {
-                $resume_linkedin = Storage::temporaryUrl($user->resume_linkedin, $expires_link);
+
+            $form = [
+                'additional_skills' => json_encode(
+                    $user->skills()->select('name', 'years')->get()->toArray(),
+                    JSON_THROW_ON_ERROR
+                ),
+            ];
+
+            if (! empty($user->github_link)) {
+                $form['github_url'] = $user->github_link;
+            }
+
+            if (! empty($user->site_link)) {
+                $form['portfolio_url'] = $user->site_link;
+            }
+
+            return $request->post('/build', $form);
+        } finally {
+            fclose($cvStream);
+
+            if (is_resource($linkedinStream)) {
+                fclose($linkedinStream);
             }
         }
-
-        if (! empty($cv_path) && Storage::exists($cv_path)) {
-            $resume_cv_stream = Storage::readStream($cv_path);
-            $resume_cv_filename = basename($cv_path);
-        }
-
-        return [
-            'additional_skills' => $user->skills()->select('name', 'years')->get()->toArray(),
-            'github_url' => $user->github_link,
-            'portfolio_url' => $user->site_link,
-            'resume_cv_stream' => $resume_cv_stream,
-            'resume_cv_filename' => $resume_cv_filename,
-            'resume_linkedin' => $resume_linkedin,
-        ];
-    }
-
-    private static function mockData()
-    {
-        return [
-            'experiences' => [
-                [
-                    'city' => 'São Paulo',
-                    'company' => 'Tech Solutions Inovações',
-                    'country' => 'Brasil',
-                    'description' => 'Desenvolvimento de APIs RESTful e integração de microsserviços de alta escala.',
-                    'end' => '2025-12',
-                    'is_actual' => false,
-                    'role' => 'Desenvolvedor Backend Pleno',
-                    'start' => '2023-01',
-                    'state' => 'SP',
-                ],
-                [
-                    'city' => 'Campinas',
-                    'company' => 'Global Logística S.A.',
-                    'country' => 'Brasil',
-                    'description' => 'Manutenção de sistemas legados e refatoração de banco de dados relacionais.',
-                    'end' => null,
-                    'is_actual' => true,
-                    'role' => 'Analista de Sistemas Senior',
-                    'start' => '2026-01',
-                    'state' => 'SP',
-                ],
-            ],
-            'header' => [
-                'contacts' => ['+55 11 99999-8888'],
-                'email' => 'silva.junior@provedor.com',
-                'emails' => ['silva.junior@provedor.com', 'contato.junior@dev.io'],
-                'headline' => 'Engenheiro de Software focado em PHP e Arquitetura de Nuvem',
-                'links' => [
-                    'linkedin' => 'https://linkedin.com',
-                    'github' => 'https://github.com',
-                    'portfolio' => 'https://meusite.dev',
-                ],
-                'location' => 'São Paulo, SP - Brasil',
-                'name' => 'Carlos Silva Júnior',
-            ],
-            'languages' => [
-                [
-                    'language' => 'Inglês',
-                    'level' => 'advanced',
-                ],
-                [
-                    'language' => 'Espanhol',
-                    'level' => 'intermediate',
-                ],
-            ],
-            'others' => [
-                'certifications' => ['AWS Certified Cloud Practitioner', 'Laravel Certified Developer'],
-            ],
-            'professional_summary' => 'Profissional com mais de 5 anos de experiência no ecossistema PHP. Especialista na criação de soluções escaláveis utilizando Laravel, Docker e arquitetura de microsserviços. Comprometido com a qualidade de código e testes automatizados.',
-            'projects' => [
-                [
-                    'description' => 'Plataforma completa de comércio eletrônico com pagamentos recorrentes e integração de estoque via API.',
-                    'end' => '2024-06',
-                    'start' => '2024-01',
-                    'technologies' => ['Laravel', 'Vue.js', 'Redis', 'PostgreSQL'],
-                    'title' => 'E-Commerce Engine X',
-                    'url' => 'https://github.com/ecommerce-engine',
-                ],
-            ],
-            'qualifications' => [
-                [
-                    'end' => '2022-12',
-                    'institution' => 'Universidade de Tecnologia do Estado',
-                    'is_coursing' => false,
-                    'start' => '2019-01',
-                    'title' => 'Bacharelado em Ciência da Computação',
-                    'type' => 'higher_education',
-                ],
-            ],
-            'score' => 85,
-            'skills' => [
-                [
-                    'name' => 'PHP / Laravel',
-                    'years' => 5,
-                ],
-                [
-                    'name' => 'Docker',
-                    'years' => 3,
-                ],
-                [
-                    'name' => 'MySQL',
-                    'years' => 5,
-                ],
-                [
-                    'name' => 'Git / GitHub Actions',
-                    'years' => 4,
-                ],
-            ],
-        ];
     }
 }

--- a/backend/app/Services/Bot/ProcessBotService.php
+++ b/backend/app/Services/Bot/ProcessBotService.php
@@ -2,68 +2,85 @@
 
 namespace App\Services\Bot;
 
+use App\Enums\UserResumeEnum;
 use App\Helpers\ResponseData;
 use App\Models\UserResume;
 use App\Services\Bot\Actions\ProcessBotAction;
 use App\Services\Bot\Actions\PublishBotAction;
 use Exception;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
 
 class ProcessBotService
 {
+    private string $baseUrl;
+
     public function __construct(
         private $http = null,
         public string $endpointBase = 'api/v1'
     ) {
         $config = config('services.bot');
 
-        $baseUrl = rtrim($config['url'] ?? '', '/');
-
-        if (empty($baseUrl)) {
-            throw new Exception('BOT_URL is not configured.');
-        }
-
-        $endpointBase = trim($this->endpointBase, '/');
-
-        $this->http = Http::acceptJson()
-            ->baseUrl($baseUrl);
-
-        $this->checkHealth();
-
-        $this->http = $this->http->baseUrl(
-            $baseUrl . '/' . $endpointBase
-        );
+        $this->baseUrl = rtrim($config['url'] ?? '', '/');
     }
 
-    protected function checkHealth(): void
+    protected function checkHealth($http): void
     {
-        $response = $this->http->get('/health');
+        $response = $http->get('/health');
 
-        if (
-            $response->status() !== 200 ||
-            ($response->json()['status'] ?? '') !== 'online'
-        ) {
+        if (! $response->successful()) {
+            throw new RequestException($response);
+        }
+
+        if ($response->json('status') !== 'online') {
             throw new Exception('BOT OFFLINE', 503);
         }
     }
 
     public function analyse(Request $request)
     {
-        try {
-            $resume = UserResume::find($request->input('user_resume_id'));
+        $resumeId = $request->input('user_resume_id');
 
-            if ($resume && $request->user()->id !== $resume->user_id) {
-                return ResponseData::success('Not found!', [
-                    'message' => 'Resume not found for this user.',
-                ], 404);
+        if (! is_string($resumeId) || ! Str::isUuid($resumeId)) {
+            return ResponseData::error('Validation error', [
+                'message' => 'A valid user_resume_id UUID is required.',
+            ], 422);
+        }
+
+        $resume = UserResume::query()
+            ->whereKey($resumeId)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if (! $resume) {
+            return ResponseData::error('Not found!', [
+                'message' => 'Resume not found for this user.',
+            ], 404);
+        }
+
+        try {
+            if (empty($this->baseUrl)) {
+                throw new Exception('BOT_URL is not configured.');
             }
+
+            $this->checkHealth(
+                Http::acceptJson()->baseUrl($this->baseUrl)
+            );
+
+            $endpointBase = trim($this->endpointBase, '/');
+            $this->http = Http::acceptJson()->baseUrl(
+                $this->baseUrl.'/'.$endpointBase
+            );
 
             $callback = (new PublishBotAction(
                 $this->http,
                 $request->user(),
-                $resume->toArray()
+                $resume
             ))::handle();
 
             $response = ProcessBotAction::handle($callback, $resume);
@@ -79,19 +96,75 @@ class ProcessBotService
         } catch (RequestException $exception) {
             $statusCode = $exception->response->status();
             $errorData = $exception->response->json();
+            $details = is_array($errorData) ? $errorData : [];
+            $message = $this->errorMessage(
+                $details['detail'] ?? $details['message'] ?? $details['error'] ?? null,
+                $exception->getMessage()
+            );
+
+            $this->markFailed($resume, $message);
 
             return ResponseData::error('Failed', [
-                'message' => $errorData['detail'] ?? $exception->getMessage(),
-                'details' => $errorData,
-            ], $statusCode);
+                'message' => $message,
+                'details' => $details,
+            ], $this->errorStatus($statusCode));
 
-        } catch (Exception $exception) {
+        } catch (ConnectionException $exception) {
+            $message = $this->errorMessage(null, $exception->getMessage());
+
+            $this->markFailed($resume, $message);
+
+            return ResponseData::error('Failed', [
+                'message' => $message,
+            ], 503);
+
+        } catch (Throwable $exception) {
             $code = $exception->getCode();
             $statusCode = ($code >= 400 && $code < 600) ? $code : 500;
+            $message = $this->errorMessage(null, $exception->getMessage());
+
+            $this->markFailed($resume, $message);
 
             return ResponseData::error('Failed', [
-                'message' => $exception->getMessage(),
+                'message' => $message,
             ], $statusCode);
         }
+    }
+
+    private function markFailed(UserResume $resume, string $message): void
+    {
+        try {
+            $resume->update([
+                'status' => UserResumeEnum::FAIL,
+                'observation' => $message,
+            ]);
+        } catch (Throwable $exception) {
+            Log::error('Failed to update resume processing status.', [
+                'user_resume_id' => $resume->id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function errorMessage(mixed $detail, string $fallback): string
+    {
+        if (is_string($detail) && $detail !== '') {
+            return $detail;
+        }
+
+        if ($detail !== null) {
+            $encoded = json_encode($detail, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+            if (is_string($encoded)) {
+                return $encoded;
+            }
+        }
+
+        return $fallback !== '' ? $fallback : 'Bot processing failed.';
+    }
+
+    private function errorStatus(int $status): int
+    {
+        return $status >= 400 && $status < 600 ? $status : 502;
     }
 }

--- a/backend/resources/views/exports/ats.blade.php
+++ b/backend/resources/views/exports/ats.blade.php
@@ -92,8 +92,13 @@
         <p>{{ $resume->header['location'] ?? '' }}</p>
 
 
-        <p>{{ implode(' / ', $resume->header['emails'] ?? []) }}</p>
-        <p>{{ implode(' / ', $resume->header['contacts'] ?? []) }}</p>
+        @php
+            $emails = $resume->header['emails'] ?? null;
+            $contacts = $resume->header['contacts'] ?? null;
+        @endphp
+
+        <p>{{ is_array($emails) ? implode(' / ', $emails) : ($emails ?? '') }}</p>
+        <p>{{ is_array($contacts) ? implode(' / ', $contacts) : ($contacts ?? '') }}</p>
 
         @if(isset($resume->header['links']))
 
@@ -216,7 +221,7 @@
 
                         <strong>Técnologias:</strong>
 
-                        {{ implode(', ', $project['technologies']) }}
+                        {{ is_array($project['technologies']) ? implode(', ', $project['technologies']) : $project['technologies'] }}
 
                     </p>
 

--- a/backend/tests/Feature/Resume/ProcessBotResumeTest.php
+++ b/backend/tests/Feature/Resume/ProcessBotResumeTest.php
@@ -1,0 +1,372 @@
+<?php
+
+use App\Enums\UserResumeEnum;
+use App\Models\ResumeAnalytic;
+use App\Models\UserResume;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request as ClientRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    Storage::fake('local');
+    config()->set('services.bot.url', 'https://resume-bot.test');
+});
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function createStoredResumeForBot(array $auth, array $attributes = []): UserResume
+{
+    $cvPath = $attributes['original_file_path_cv'] ?? 'resumes/cv/source-real.pdf';
+    $linkedinPath = $attributes['original_file_path_linkedin'] ?? null;
+
+    if ($cvPath !== null) {
+        Storage::put($cvPath, 'REAL_CV_FILE_CONTENT');
+    }
+
+    if ($linkedinPath !== null) {
+        Storage::put($linkedinPath, 'REAL_LINKEDIN_PDF_CONTENT');
+    }
+
+    return $auth['user']->resumes()->create(array_merge([
+        'original_file_path_cv' => $cvPath,
+        'original_file_path_linkedin' => $linkedinPath,
+    ], $attributes));
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function uniqueBotResumePayload(): array
+{
+    return [
+        'score' => 97,
+        'professional_summary' => 'REAL BOT SUMMARY 7f5d8a',
+        'header' => [
+            'name' => 'REAL BOT NAME 7f5d8a',
+            'headline' => 'Real bot headline',
+            'email' => 'real-bot@example.test',
+            'emails' => 'real-bot@example.test',
+            'contacts' => '+55 71 90000-1234',
+            'location' => 'Salvador, BA',
+            'links' => ['GitHub' => 'https://github.com/real-bot'],
+        ],
+        'experiences' => [[
+            'company' => 'REAL BOT COMPANY 7f5d8a',
+            'role' => 'Platform Engineer',
+            'start' => '2024-01',
+            'end' => null,
+            'description' => 'Built the real processing path.',
+            'is_actual' => true,
+            'city' => 'Salvador',
+            'state' => 'BA',
+            'country' => 'Brasil',
+        ]],
+        'projects' => [[
+            'title' => 'REAL BOT PROJECT 7f5d8a',
+            'start' => '2025-01',
+            'end' => null,
+            'technologies' => 'Laravel, React',
+            'description' => 'Project returned only by the fake bot.',
+            'url' => 'https://example.test/real-project',
+        ]],
+        'qualifications' => [],
+        'skills' => [['name' => 'REAL BOT SKILL 7f5d8a', 'years' => 6]],
+        'languages' => [['language' => 'Português', 'level' => 'native']],
+        'others' => ['source' => 'REAL BOT OTHER 7f5d8a'],
+    ];
+}
+
+it('persists and returns only the real successful bot build response', function () {
+    $auth = actingAsUser();
+    $auth['user']->forceFill([
+        'github_link' => 'https://github.com/multipart-real',
+        'site_link' => 'https://portfolio.example.test',
+    ])->save();
+    $auth['user']->skills()->create(['name' => 'Rust', 'years' => 7]);
+
+    $resume = createStoredResumeForBot($auth, [
+        'original_file_path_cv' => 'resumes/cv/source-real.docx',
+        'original_file_path_linkedin' => 'resumes/linkedin/linkedin-real.pdf',
+    ]);
+    $botPayload = uniqueBotResumePayload();
+    $multipart = [];
+
+    Http::fake(function (ClientRequest $request) use (&$multipart, $botPayload) {
+        if ($request->url() === 'https://resume-bot.test/health') {
+            return Http::response(['status' => 'online'], 200);
+        }
+
+        if ($request->url() === 'https://resume-bot.test/api/v1/build') {
+            foreach ($request->data() as $part) {
+                $contents = $part['contents'];
+
+                if (is_resource($contents)) {
+                    $contents = stream_get_contents($contents);
+                    rewind($part['contents']);
+                }
+
+                $multipart[$part['name']] = [
+                    'contents' => $contents,
+                    'filename' => $part['filename'] ?? null,
+                ];
+            }
+
+            return Http::response($botPayload, 200);
+        }
+
+        return Http::response(['detail' => 'Unexpected test URL'], 500);
+    });
+
+    $response = $this
+        ->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', [
+            'user_resume_id' => $resume->id,
+        ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.0.header.name', 'REAL BOT NAME 7f5d8a')
+        ->assertJsonPath('data.0.header.summary', 'REAL BOT SUMMARY 7f5d8a')
+        ->assertJsonPath('data.0.experiences.0.company', 'REAL BOT COMPANY 7f5d8a')
+        ->assertJsonPath('data.0.others.score', 97)
+        ->assertJsonMissing(['name' => 'Carlos Silva Júnior'])
+        ->assertJsonMissing(['score' => 85]);
+
+    $analytic = ResumeAnalytic::query()->sole();
+
+    expect($analytic->status)->toBe('success')
+        ->and($analytic->header['name'])->toBe('REAL BOT NAME 7f5d8a')
+        ->and($analytic->header['emails'])->toBe('real-bot@example.test')
+        ->and($analytic->experiences[0]['company'])->toBe('REAL BOT COMPANY 7f5d8a')
+        ->and($analytic->projects[0]['technologies'])->toBe('Laravel, React')
+        ->and($analytic->others['score'])->toBe(97)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::ANALYZE)
+        ->and($resume->fresh()->observation)->toBeNull();
+
+    expect($multipart['resume_cv'])->toBe([
+        'contents' => 'REAL_CV_FILE_CONTENT',
+        'filename' => 'source-real.docx',
+    ])->and($multipart['resume_linkedin'])->toBe([
+        'contents' => 'REAL_LINKEDIN_PDF_CONTENT',
+        'filename' => 'linkedin-real.pdf',
+    ])->and($multipart['github_url']['contents'])->toBe('https://github.com/multipart-real')
+        ->and($multipart['portfolio_url']['contents'])->toBe('https://portfolio.example.test')
+        ->and(json_decode($multipart['additional_skills']['contents'], true))->toBe([
+            ['name' => 'Rust', 'years' => 7],
+        ]);
+
+    Http::assertSentCount(2);
+    Http::assertSent(fn (ClientRequest $request) => $request->url() === 'https://resume-bot.test/health'
+        && $request->method() === 'GET'
+    );
+    Http::assertSent(fn (ClientRequest $request) => $request->url() === 'https://resume-bot.test/api/v1/build'
+        && $request->method() === 'POST'
+        && $request->hasFile('resume_cv', null, 'source-real.docx')
+        && $request->hasFile('resume_linkedin', null, 'linkedin-real.pdf')
+    );
+});
+
+it('omits the optional LinkedIn multipart field when no stored file exists', function () {
+    $auth = actingAsUser();
+    $resume = createStoredResumeForBot($auth);
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response(['status' => 'online']),
+        'https://resume-bot.test/api/v1/build' => Http::response(uniqueBotResumePayload()),
+    ]);
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
+        ->assertOk();
+
+    Http::assertSent(fn (ClientRequest $request) => $request->url() === 'https://resume-bot.test/api/v1/build'
+        && $request->hasFile('resume_cv', null, 'source-real.pdf')
+        && ! $request->hasFile('resume_linkedin')
+    );
+});
+
+it('preserves a bot validation failure and never persists fictional analytics', function () {
+    $auth = actingAsUser();
+    $resume = createStoredResumeForBot($auth);
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response(['status' => 'online']),
+        'https://resume-bot.test/api/v1/build' => Http::response([
+            'detail' => 'REAL BOT 422 DETAIL 04c1',
+        ], 422),
+    ]);
+
+    $response = $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id]);
+
+    $response->assertUnprocessable()
+        ->assertJsonPath('data.message', 'REAL BOT 422 DETAIL 04c1')
+        ->assertJsonPath('data.details.detail', 'REAL BOT 422 DETAIL 04c1')
+        ->assertJsonMissing(['name' => 'Carlos Silva Júnior'])
+        ->assertJsonMissing(['score' => 85]);
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe('REAL BOT 422 DETAIL 04c1');
+});
+
+it('preserves a bot service failure and never persists fictional analytics', function () {
+    $auth = actingAsUser();
+    $resume = createStoredResumeForBot($auth);
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response(['status' => 'online']),
+        'https://resume-bot.test/api/v1/build' => Http::response([
+            'detail' => 'REAL BOT 503 DETAIL b38e',
+        ], 503),
+    ]);
+
+    $response = $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id]);
+
+    $response->assertServiceUnavailable()
+        ->assertJsonPath('data.message', 'REAL BOT 503 DETAIL b38e')
+        ->assertJsonPath('data.details.detail', 'REAL BOT 503 DETAIL b38e')
+        ->assertJsonMissing(['name' => 'Carlos Silva Júnior'])
+        ->assertJsonMissing(['score' => 85]);
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe('REAL BOT 503 DETAIL b38e');
+});
+
+it('marks the resume failed when the bot health endpoint is unavailable', function () {
+    $auth = actingAsUser();
+    $resume = createStoredResumeForBot($auth);
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response([
+            'detail' => 'BOT HEALTH UNAVAILABLE 2a19',
+        ], 503),
+    ]);
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
+        ->assertServiceUnavailable()
+        ->assertJsonPath('data.message', 'BOT HEALTH UNAVAILABLE 2a19');
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe('BOT HEALTH UNAVAILABLE 2a19');
+
+    Http::assertSentCount(1);
+});
+
+it('returns service unavailable and marks the resume failed on a connection or timeout error', function (string $message) {
+    $auth = actingAsUser();
+    $resume = createStoredResumeForBot($auth);
+
+    Http::fake(fn () => throw new ConnectionException($message));
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
+        ->assertServiceUnavailable()
+        ->assertJsonPath('data.message', $message);
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe($message);
+})->with([
+    'connection failure' => 'CONNECTION FAILURE 8ce2',
+    'timeout' => 'BOT REQUEST TIMED OUT 52b1',
+]);
+
+it('rejects a missing or invalid resume UUID before contacting the bot', function (?string $resumeId) {
+    $auth = actingAsUser();
+    Http::preventStrayRequests();
+
+    $payload = $resumeId === null ? [] : ['user_resume_id' => $resumeId];
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', $payload)
+        ->assertUnprocessable()
+        ->assertJsonPath('data.message', 'A valid user_resume_id UUID is required.');
+
+    Http::assertNothingSent();
+})->with([
+    'missing UUID' => null,
+    'invalid UUID' => 'not-a-uuid',
+]);
+
+it('returns not found for nonexistent or unauthorized resumes without contacting the bot', function (bool $otherUserOwnsResume) {
+    $auth = actingAsUser();
+    Http::preventStrayRequests();
+
+    $resumeId = (string) Str::uuid();
+
+    if ($otherUserOwnsResume) {
+        $resumeId = authUser()->resumes()->create([
+            'original_file_path_cv' => 'resumes/cv/other-user.pdf',
+        ])->id;
+    }
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resumeId])
+        ->assertNotFound()
+        ->assertJsonPath('data.message', 'Resume not found for this user.');
+
+    Http::assertNothingSent();
+})->with([
+    'nonexistent resume' => false,
+    'resume owned by another user' => true,
+]);
+
+it('marks the resume failed when its required CV is missing', function () {
+    $auth = actingAsUser();
+    $resume = $auth['user']->resumes()->create([
+        'original_file_path_cv' => 'resumes/cv/missing.pdf',
+    ]);
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response(['status' => 'online']),
+    ]);
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
+        ->assertUnprocessable()
+        ->assertJsonPath('data.message', 'Resume CV file is missing.');
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe('Resume CV file is missing.');
+
+    Http::assertSentCount(1);
+});
+
+it('marks the resume failed when its required CV cannot be opened', function () {
+    $auth = actingAsUser();
+    $resume = $auth['user']->resumes()->create([
+        'original_file_path_cv' => 'resumes/cv/unreadable.pdf',
+    ]);
+
+    Storage::shouldReceive('exists')
+        ->once()
+        ->with('resumes/cv/unreadable.pdf')
+        ->andReturnTrue();
+    Storage::shouldReceive('readStream')
+        ->once()
+        ->with('resumes/cv/unreadable.pdf')
+        ->andReturnFalse();
+
+    Http::fake([
+        'https://resume-bot.test/health' => Http::response(['status' => 'online']),
+    ]);
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
+        ->assertInternalServerError()
+        ->assertJsonPath('data.message', 'Resume CV file could not be opened.');
+
+    expect(ResumeAnalytic::query()->count())->toBe(0)
+        ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
+        ->and($resume->fresh()->observation)->toBe('Resume CV file could not be opened.');
+
+    Http::assertSentCount(1);
+});

--- a/backend/tests/Feature/Resume/ResumeDocumentServiceTest.php
+++ b/backend/tests/Feature/Resume/ResumeDocumentServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\ResumeAnalytic;
+use App\Services\Resume\ResumeDocumentService;
+use Illuminate\Support\Facades\Storage;
+
+it('generates the ATS PDF when real bot scalar fields are strings or null', function () {
+    Storage::fake('local');
+
+    $cases = [
+        [
+            'name' => 'String Contract Resume',
+            'contacts' => '+55 71 99999-0000',
+            'emails' => null,
+            'technologies' => 'Laravel, React',
+        ],
+        [
+            'name' => 'Null Contract Resume',
+            'contacts' => null,
+            'emails' => 'candidate@example.test',
+            'technologies' => null,
+        ],
+        [
+            'name' => 'Array Compatibility Resume',
+            'contacts' => ['+55 71 99999-0000'],
+            'emails' => ['candidate@example.test'],
+            'technologies' => ['Laravel', 'React'],
+        ],
+    ];
+
+    foreach ($cases as $case) {
+        $resume = new ResumeAnalytic;
+        $resume->forceFill([
+            'header' => [
+                'name' => $case['name'],
+                'headline' => null,
+                'location' => null,
+                'contacts' => $case['contacts'],
+                'emails' => $case['emails'],
+                'links' => [],
+                'summary' => 'Summary from the real bot response shape.',
+            ],
+            'experiences' => [],
+            'projects' => [[
+                'title' => 'Contract-safe project',
+                'description' => null,
+                'url' => null,
+                'technologies' => $case['technologies'],
+            ]],
+            'qualifications' => [],
+            'skills' => [],
+            'languages' => [],
+            'others' => [],
+        ]);
+
+        $path = app(ResumeDocumentService::class)->generate($resume);
+
+        Storage::disk('local')->assertExists($path);
+    }
+});

--- a/backend/tests/Feature/Resume/StoreNewResumeTest.php
+++ b/backend/tests/Feature/Resume/StoreNewResumeTest.php
@@ -53,6 +53,60 @@ it('fails with only links, no files', function () {
     ]);
 });
 
+it('accepts a DOCX CV supported by the bot', function () {
+
+    Storage::fake('local');
+
+    $auth = actingAsUser();
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'resume_cv' => UploadedFile::fake()->create(
+                'cv.docx',
+                100,
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            ),
+        ])
+        ->assertOk();
+
+    expect($auth['user']->resumes()->count())->toBe(1);
+});
+
+it('rejects a CV format unsupported by the bot', function () {
+
+    Storage::fake('local');
+
+    $auth = actingAsUser();
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'resume_cv' => UploadedFile::fake()->create('cv.doc', 100, 'application/msword'),
+        ])
+        ->assertUnprocessable();
+
+    expect($auth['user']->resumes()->count())->toBe(0);
+});
+
+it('rejects a LinkedIn format unsupported by the bot', function () {
+
+    Storage::fake('local');
+
+    $auth = actingAsUser();
+
+    $this->withHeaders($auth['headers'])
+        ->postJson('/api/client/resumes/new-resume', [
+            'resume_cv' => UploadedFile::fake()->create('cv.pdf', 100, 'application/pdf'),
+            'resume_linkedin' => UploadedFile::fake()->create(
+                'linkedin.docx',
+                100,
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            ),
+        ])
+        ->assertUnprocessable();
+
+    expect($auth['user']->resumes()->count())->toBe(0);
+});
+
 it('requires authentication', function () {
 
     $this->postJson('/api/client/resumes/new-resume')

--- a/frontend/src/components/resume-upload/resume-analytic-adapter.test.ts
+++ b/frontend/src/components/resume-upload/resume-analytic-adapter.test.ts
@@ -9,7 +9,7 @@ const analytic: ResumeAnalytic = {
   user_resume_id: "resume-uuid",
   status: "analyze",
   error: null,
-  header: { name: "Pedro Aruanã" },
+  header: { name: "Pedro Aruanã", emails: "pedro@example.com" },
   experiences: [
     { company: "WhiteHats", role: "Dev", start: "2023-01", end: "2026-01", is_actual: false },
     { company: "Bom Currículo", role: "Voluntário", start: "2025-01", end: null, is_actual: true },
@@ -63,7 +63,7 @@ describe("filterAnalyticBySelection", () => {
   it("always passes header and others through untouched", () => {
     const filtered = filterAnalyticBySelection(analytic, []);
 
-    expect(filtered.header).toEqual({ name: "Pedro Aruanã" });
+    expect(filtered.header).toEqual({ name: "Pedro Aruanã", emails: "pedro@example.com" });
     expect(filtered.others).toEqual({ score: 85 });
   });
 });

--- a/frontend/src/pages/dashboard/resumes/NewResume.test.tsx
+++ b/frontend/src/pages/dashboard/resumes/NewResume.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import NewResume from "@/pages/dashboard/resumes/NewResume";
+
+const {
+  analyseResumeMock,
+  createResumeMock,
+  listUserResumesMock,
+  toastErrorMock,
+  toastSuccessMock,
+} = vi.hoisted(() => ({
+  analyseResumeMock: vi.fn(),
+  createResumeMock: vi.fn(),
+  listUserResumesMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("@/api/resume", () => ({
+  analyseResume: analyseResumeMock,
+  createResume: createResumeMock,
+  listUserResumes: listUserResumesMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <NewResume />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("NewResume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("accepts only bot-supported resume and LinkedIn file formats", () => {
+    const { container } = renderPage();
+
+    expect(container.querySelector("#resume_pdf")).toHaveAttribute("accept", ".pdf,.docx");
+    expect(container.querySelector("#linkedin_pdf")).toHaveAttribute("accept", ".pdf");
+    expect(screen.getByText("Selecionar arquivo (PDF ou DOCX)")).toBeInTheDocument();
+  });
+
+  it("shows the real processing error instead of reporting success", async () => {
+    const user = userEvent.setup();
+    createResumeMock.mockResolvedValue(undefined);
+    listUserResumesMock.mockResolvedValue([{ id: "resume-real-error" }]);
+    analyseResumeMock.mockRejectedValue(new Error("Bot indisponível"));
+    const { container } = renderPage();
+    const resumeInput = container.querySelector<HTMLInputElement>("#resume_pdf");
+
+    expect(resumeInput).not.toBeNull();
+    await user.upload(resumeInput!, new File(["resume"], "resume.pdf", { type: "application/pdf" }));
+    await user.click(screen.getByRole("button", { name: "Gerar Currículo com IA" }));
+
+    await waitFor(() => {
+      expect(analyseResumeMock).toHaveBeenCalledWith("resume-real-error");
+      expect(toastErrorMock).toHaveBeenCalledWith("Bot indisponível");
+      expect(screen.getByText("Bot indisponível")).toBeInTheDocument();
+    });
+
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/dashboard/resumes/NewResume.tsx
+++ b/frontend/src/pages/dashboard/resumes/NewResume.tsx
@@ -97,7 +97,7 @@ export default function NewResume() {
     e.preventDefault();
 
     if (!resumePdf) {
-      toast.error('Por favor, anexe o PDF do seu currículo atual (obrigatório).');
+      toast.error('Por favor, anexe o PDF ou DOCX do seu currículo atual (obrigatório).');
       return;
     }
 
@@ -116,7 +116,7 @@ export default function NewResume() {
       <form onSubmit={handleSubmit} className="rounded-2xl border border-slate-200 bg-white p-8 shadow-[0_4px_12px_rgba(0,0,0,0.03)]">
 
         <section className="mb-5">
-          <h2 className="mb-4 text-lg font-semibold text-slate-800">1. Documentos PDF</h2>
+          <h2 className="mb-4 text-lg font-semibold text-slate-800">1. Documentos</h2>
           <div className="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-5">
 
             <div className="flex flex-col gap-2">
@@ -126,14 +126,14 @@ export default function NewResume() {
               <div className="cursor-pointer rounded-[10px] border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-3">
                 <input
                   type="file"
-                  accept=".pdf,.doc,.docx"
+                  accept=".pdf,.docx"
                   id="resume_pdf"
                   className="hidden"
                   onChange={handleResumeChange}
                 />
                 <label htmlFor="resume_pdf" className="flex cursor-pointer items-center gap-2.5 text-sm font-medium text-slate-600">
                   <Upload size={20} color="#2563eb" />
-                  <span>{resumePdf ? resumePdf.name : 'Selecionar arquivo (PDF, DOC ou DOCX)'}</span>
+                  <span>{resumePdf ? resumePdf.name : 'Selecionar arquivo (PDF ou DOCX)'}</span>
                 </label>
               </div>
             </div>
@@ -143,7 +143,7 @@ export default function NewResume() {
               <div className="cursor-pointer rounded-[10px] border-2 border-dashed border-slate-300 bg-slate-50 px-4 py-3">
                 <input
                   type="file"
-                  accept=".pdf,.doc,.docx"
+                  accept=".pdf"
                   id="linkedin_pdf"
                   className="hidden"
                   onChange={handleLinkedinChange}

--- a/frontend/src/types/resume.ts
+++ b/frontend/src/types/resume.ts
@@ -20,7 +20,7 @@ export interface AnalyticHeader {
   email?: string | null;
   location?: string | null;
   contacts?: string[] | string | null;
-  emails?: string[] | null;
+  emails?: string | string[] | null;
   links?: Record<string, string>;
   summary?: string | null;
   [key: string]: unknown;


### PR DESCRIPTION
## Description

Fix the resume processing flow so failed bot responses are no longer replaced with mocked resume data and persisted as successful analyses.

The Laravel integration already propagates real `/api/v1/build` data to the frontend on successful processing. The issue was that bot failures such as `422`, `503`, connection errors, timeouts, or invalid responses were being replaced with a hardcoded resume payload.

This change removes the production mock fallback, preserves real bot errors, fixes the LinkedIn multipart upload, aligns accepted file formats with the bot contract, and improves PDF/frontend handling for the real response shape.

## AI Usage

* [ ] Vibe coding
* [x] Research

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation
* [ ] Chore / Infrastructure

## Affected area

* [x] Frontend
* [x] Backend
* [ ] Mobile
* [ ] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [x] Added/updated tests when necessary
* [x] Updated the documentation when necessary

## How to test

1. Upload a resume in PDF or DOCX format.
2. Optionally upload a LinkedIn resume in PDF format.
3. Process the resume through the bot.
4. Verify that a successful bot response persists and displays the real resume data.
5. Simulate or trigger a bot validation/service failure and verify that:
   - no mocked resume data is persisted;
   - the resume is marked as failed;
   - the real error is returned instead of a successful fake analysis.
6. Finish a successfully processed resume and verify that the generated PDF handles string, array, and null values correctly.

### Validation performed

- Laravel: 81 tests passed, 255 assertions
- Bot: 69 tests passed
- Frontend: 35 tests passed
- TypeScript/Vite build passed
- ESLint passed
- Laravel Pint passed
- Integrated Docker smoke test passed
- `git diff --check` passed