### PR TITLE
fix(bot): optimize Ollama inference and align timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,20 @@ REDIS_PORT=6379
 BACKEND_PORT=9000
 FRONTEND_PORT=5173
 BOT_PORT=8000
+
+# Docker-internal Ollama endpoint used by the bot container. The model is
+# downloaded automatically into the ollama_data volume on first startup.
+OLLAMA_IMAGE=ollama/ollama:0.33.3
+OLLAMA_PORT=11434
+OLLAMA_BASE_URL=http://ollama:11434
+OLLAMA_MODEL=qwen3:4b
+OLLAMA_REASONING=false
+OLLAMA_NUM_PREDICT=2048
+
+# The bot stops inference first, Laravel has time to receive its structured
+# error, and Nginx remains the outermost timeout in the request chain.
+BOT_INFERENCE_DEADLINE_SECONDS=240
+BOT_URL=http://bot:8000
+BOT_CONNECT_TIMEOUT_SECONDS=5
+BOT_HEALTH_TIMEOUT_SECONDS=5
+BOT_TIMEOUT_SECONDS=260

--- a/README.md
+++ b/README.md
@@ -89,11 +89,39 @@ Copy-Item bot/.env.example bot/.env
 docker compose up --build
 ```
 
+The Docker stack includes Ollama and automatically downloads the model defined
+by `OLLAMA_MODEL` (default: `qwen3:4b`) into the persistent `ollama_data`
+volume. The first startup can take several minutes because that model is about
+2.5 GB. The bot reaches Ollama through the Docker network at
+`http://ollama:11434`; it does not use the bot container's `localhost`.
+
+The local default favors CPU-only development. Resume requests disable Qwen's
+thinking mode, cap generated output at 2048 tokens, and stop the complete AI
+provider chain after 240 seconds. Laravel waits up to 260 seconds for the bot,
+while Nginx waits up to 280 seconds, allowing a bot timeout to reach the client
+as a structured response. On a Ryzen 7 5700G, a representative dense resume
+completed with `qwen3:4b` in about 209 seconds; slower CPU-only machines may
+still need a faster external provider or an asynchronous workflow.
+
+To confirm that the model is available or download it again:
+
+```bash
+docker compose exec ollama ollama list
+docker compose exec ollama ollama pull qwen3:4b
+```
+
+Set `OLLAMA_MODEL` in the root `.env` before starting the stack to use another
+model. `OLLAMA_BASE_URL` may point the bot at an external Ollama deployment
+instead, but its address must be reachable from inside the bot container. For
+better local quality on sufficiently fast hardware, set `OLLAMA_MODEL=qwen3:8b`;
+that model is about 5.2 GB and remains fully supported.
+
 Services:
 
 - Frontend: http://localhost:5173
 - Backend: http://localhost:9000
 - Bot: http://localhost:8000
+- Ollama: http://localhost:11434
 
 Health endpoints:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,3 +63,10 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 SANCTUM_STATEFUL_DOMAINS=localhost:5173,127.0.0.1:5173
+
+# Direct host development default. Docker Compose overrides this with
+# http://bot:8000 on the internal network.
+BOT_URL=http://127.0.0.1:8000
+BOT_CONNECT_TIMEOUT_SECONDS=5
+BOT_HEALTH_TIMEOUT_SECONDS=5
+BOT_TIMEOUT_SECONDS=260

--- a/backend/app/Services/Bot/ProcessBotService.php
+++ b/backend/app/Services/Bot/ProcessBotService.php
@@ -20,6 +20,12 @@ class ProcessBotService
 {
     private string $baseUrl;
 
+    private float $connectTimeout;
+
+    private float $healthTimeout;
+
+    private float $requestTimeout;
+
     public function __construct(
         private $http = null,
         public string $endpointBase = 'api/v1'
@@ -27,6 +33,9 @@ class ProcessBotService
         $config = config('services.bot');
 
         $this->baseUrl = rtrim($config['url'] ?? '', '/');
+        $this->connectTimeout = (float) ($config['connect_timeout_seconds'] ?? 5);
+        $this->healthTimeout = (float) ($config['health_timeout_seconds'] ?? 5);
+        $this->requestTimeout = (float) ($config['timeout_seconds'] ?? 260);
     }
 
     protected function checkHealth($http): void
@@ -69,13 +78,17 @@ class ProcessBotService
             }
 
             $this->checkHealth(
-                Http::acceptJson()->baseUrl($this->baseUrl)
+                Http::acceptJson()
+                    ->connectTimeout($this->connectTimeout)
+                    ->timeout($this->healthTimeout)
+                    ->baseUrl($this->baseUrl)
             );
 
             $endpointBase = trim($this->endpointBase, '/');
-            $this->http = Http::acceptJson()->baseUrl(
-                $this->baseUrl.'/'.$endpointBase
-            );
+            $this->http = Http::acceptJson()
+                ->connectTimeout($this->connectTimeout)
+                ->timeout($this->requestTimeout)
+                ->baseUrl($this->baseUrl.'/'.$endpointBase);
 
             $callback = (new PublishBotAction(
                 $this->http,
@@ -110,7 +123,13 @@ class ProcessBotService
             ], $this->errorStatus($statusCode));
 
         } catch (ConnectionException $exception) {
-            $message = $this->errorMessage(null, $exception->getMessage());
+            Log::error('Bot service connection failed.', [
+                'user_resume_id' => $resume->id,
+                'bot_url' => $this->baseUrl,
+                'exception' => $exception,
+            ]);
+
+            $message = 'Bot service is unavailable.';
 
             $this->markFailed($resume, $message);
 

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -46,8 +46,10 @@ return [
     ],
 
     'bot' => [
-        'url' => env('BOT_URL', 'http://0.0.0.0:9000'),
-        //'url' => 'http://localhost:8000',
+        'url' => env('BOT_URL', 'http://127.0.0.1:8000'),
+        'connect_timeout_seconds' => (float) env('BOT_CONNECT_TIMEOUT_SECONDS', 5),
+        'health_timeout_seconds' => (float) env('BOT_HEALTH_TIMEOUT_SECONDS', 5),
+        'timeout_seconds' => (float) env('BOT_TIMEOUT_SECONDS', 260),
     ],
 
 ];

--- a/backend/tests/Feature/Resume/ProcessBotResumeTest.php
+++ b/backend/tests/Feature/Resume/ProcessBotResumeTest.php
@@ -93,8 +93,14 @@ it('persists and returns only the real successful bot build response', function 
     ]);
     $botPayload = uniqueBotResumePayload();
     $multipart = [];
+    $requestOptions = [];
 
-    Http::fake(function (ClientRequest $request) use (&$multipart, $botPayload) {
+    Http::fake(function (ClientRequest $request, array $options) use (&$multipart, &$requestOptions, $botPayload) {
+        $requestOptions[$request->url()] = [
+            'connect_timeout' => $options['connect_timeout'],
+            'timeout' => $options['timeout'],
+        ];
+
         if ($request->url() === 'https://resume-bot.test/health') {
             return Http::response(['status' => 'online'], 200);
         }
@@ -155,6 +161,12 @@ it('persists and returns only the real successful bot build response', function 
         ->and($multipart['portfolio_url']['contents'])->toBe('https://portfolio.example.test')
         ->and(json_decode($multipart['additional_skills']['contents'], true))->toBe([
             ['name' => 'Rust', 'years' => 7],
+        ])->and($requestOptions['https://resume-bot.test/health'])->toBe([
+            'connect_timeout' => 5.0,
+            'timeout' => 5.0,
+        ])->and($requestOptions['https://resume-bot.test/api/v1/build'])->toBe([
+            'connect_timeout' => 5.0,
+            'timeout' => 260.0,
         ]);
 
     Http::assertSentCount(2);
@@ -268,11 +280,12 @@ it('returns service unavailable and marks the resume failed on a connection or t
     $this->withHeaders($auth['headers'])
         ->postJson('/api/client/services/bot/process', ['user_resume_id' => $resume->id])
         ->assertServiceUnavailable()
-        ->assertJsonPath('data.message', $message);
+        ->assertJsonPath('data.message', 'Bot service is unavailable.')
+        ->assertJsonMissing(['message' => $message]);
 
     expect(ResumeAnalytic::query()->count())->toBe(0)
         ->and($resume->fresh()->status)->toBe(UserResumeEnum::FAIL)
-        ->and($resume->fresh()->observation)->toBe($message);
+        ->and($resume->fresh()->observation)->toBe('Bot service is unavailable.');
 })->with([
     'connection failure' => 'CONNECTION FAILURE 8ce2',
     'timeout' => 'BOT REQUEST TIMED OUT 52b1',

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,5 +1,5 @@
-# Secrets only. Non-secret configuration (models, timeouts, provider chain,
-# ...) lives in config.yaml.
+# Secrets and deployment-specific overrides. Other non-secret configuration
+# (timeouts, provider chain, ...) lives in config.yaml.
 
 GROQ_API_KEY=
 GEMINI_API_KEY=
@@ -18,3 +18,11 @@ IA_PROVIDER=auto
 IA_PROVIDER_CHAIN=groq,gemini,deepseek,openai,ollama
 USAR_IA_PADRAO=false
 LOG_LEVEL=INFO
+
+# Defaults for running the bot directly on the host. Docker Compose overrides
+# the URL with http://ollama:11434 so it never targets its own container.
+OLLAMA_BASE_URL=http://127.0.0.1:11434
+OLLAMA_MODEL=qwen3:4b
+OLLAMA_REASONING=false
+OLLAMA_NUM_PREDICT=2048
+BOT_INFERENCE_DEADLINE_SECONDS=240

--- a/bot/README.md
+++ b/bot/README.md
@@ -252,16 +252,46 @@ cp .env.example .env                 # secrets
 
 `config.yaml` holds every non-secret setting (provider models/timeouts,
 provider chain, log level, AI output language) — see `config.yaml.example`
-for the full, commented structure. `.env` holds secrets only:
+for the full, commented structure. `.env` holds secrets and
+deployment-specific overrides:
 
 - `GROQ_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`
 - `GITHUB_TOKEN` — optional, raises the GitHub REST API rate limit for
   **GitHub enrichment** above (unauthenticated works fine, just at a lower
   limit).
 
-A few legacy operational environment variables still override their
-`config.yaml` counterpart for per-deployment flexibility: `IA_PROVIDER`,
-`IA_PROVIDER_CHAIN`, `USAR_IA_PADRAO`, `LOG_LEVEL`.
+Operational environment variables can override selected `config.yaml` values
+for per-deployment flexibility: `IA_PROVIDER`, `IA_PROVIDER_CHAIN`,
+`USAR_IA_PADRAO`, `LOG_LEVEL`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`,
+`OLLAMA_REASONING`, `OLLAMA_NUM_PREDICT`, and
+`BOT_INFERENCE_DEADLINE_SECONDS`.
+
+When the bot runs directly on the host, the example configuration connects to
+Ollama at `http://127.0.0.1:11434`. The root Docker Compose stack instead sets
+`OLLAMA_BASE_URL=http://ollama:11434`, starts an Ollama service, and downloads
+`OLLAMA_MODEL` (default `qwen3:4b`, about 2.5 GB) before starting the bot. This
+smaller member of the same Qwen3 family is the CPU-oriented development
+default; `qwen3:8b` remains available by setting `OLLAMA_MODEL` and requires a
+download of about 5.2 GB. Do not use
+`localhost` to reach a host-side Ollama instance from inside the bot container;
+use an address that is routable from that container.
+
+For resume build and analysis, Ollama defaults to `reasoning: false` and
+`num_predict: 2048`. LangChain still sends the Pydantic JSON Schema through
+`with_structured_output`; the prompt does not repeat that schema as text. The
+120-second Ollama HTTP setting is an inactivity timeout. The separate
+240-second inference deadline is a wall-clock limit over the complete provider
+chain, including active token generation. The root stack then gives Laravel
+260 seconds and Nginx 280 seconds, leaving each inner layer time to return a
+structured response before the next layer closes the connection.
+
+For a host-side setup, install/start Ollama and make the configured model
+available before starting the bot:
+
+```bash
+ollama pull qwen3:4b
+ollama list
+```
 
 If `config.yaml` is missing entirely, `Settings.load()` falls back to empty
 non-secret configuration (no provider models/timeouts) rather than failing
@@ -274,7 +304,8 @@ Supported providers are Groq, Gemini, DeepSeek, OpenAI, Ollama, and Mock, all
 built by `ProviderFactory` from `config.yaml`. Selection defaults to `auto`
 (walks `ai.provider_chain` in order, skipping unconfigured providers, trying
 the next one on failure or an invalid structured response).
-Provider failures are sanitized before logging or returning diagnostics.
+Provider failures are logged internally with their exception chain and are
+sanitized before an error is returned to API clients.
 
 Resume text is sent to the configured provider as-is — the bot does not
 strip personal data before this call, since the AI is asked to return the

--- a/bot/app/core/settings.py
+++ b/bot/app/core/settings.py
@@ -2,9 +2,8 @@
 
 Non-secret values are read from ``config.yaml``. Secrets (API keys) are read
 only from the environment / ``.env`` and are never written to the YAML file.
-A handful of legacy environment variables (``IA_PROVIDER``, ...) still
-override their ``config.yaml`` counterpart, preserving current deployment
-behavior.
+Operational environment variables (``IA_PROVIDER``, ``OLLAMA_BASE_URL``, ...)
+can override their ``config.yaml`` counterpart for each deployment.
 """
 
 from __future__ import annotations
@@ -34,6 +33,8 @@ class ProviderSettings:
     timeout_seconds: float
     api_key: str = ""
     base_url: str | None = None
+    reasoning: bool | None = None
+    max_output_tokens: int | None = None
 
     def is_configured(self) -> bool:
         if self.base_url is not None:
@@ -48,6 +49,7 @@ class AISettings:
     provider: str
     provider_chain: tuple[str, ...]
     providers: dict[str, ProviderSettings] = field(default_factory=dict)
+    inference_deadline_seconds: float = 240.0
 
 
 @dataclass(frozen=True)
@@ -99,15 +101,29 @@ class Settings:
 
     @staticmethod
     def _build_ai_settings(raw: dict) -> AISettings:
-        providers = {
-            name: ProviderSettings(
-                model=provider_raw["model"],
+        providers: dict[str, ProviderSettings] = {}
+        for name, provider_raw in (raw.get("providers") or {}).items():
+            model = provider_raw["model"]
+            base_url = provider_raw.get("base_url")
+            reasoning = provider_raw.get("reasoning")
+            max_output_tokens = provider_raw.get("num_predict")
+
+            if name == "ollama":
+                model = os.getenv("OLLAMA_MODEL", model)
+                base_url = os.getenv("OLLAMA_BASE_URL", base_url)
+                reasoning = _env_flag("OLLAMA_REASONING", bool(reasoning))
+                max_output_tokens = int(
+                    os.getenv("OLLAMA_NUM_PREDICT", max_output_tokens or 2048)
+                )
+
+            providers[name] = ProviderSettings(
+                model=model,
                 timeout_seconds=float(provider_raw.get("timeout_seconds", 120.0)),
                 api_key=os.getenv(_PROVIDER_KEY_ENV_VARS.get(name, ""), ""),
-                base_url=provider_raw.get("base_url"),
+                base_url=base_url,
+                reasoning=reasoning,
+                max_output_tokens=max_output_tokens,
             )
-            for name, provider_raw in (raw.get("providers") or {}).items()
-        }
         default_chain = ",".join(raw.get("provider_chain") or [])
         chain = tuple(
             item.strip().lower()
@@ -120,6 +136,12 @@ class Settings:
             provider=os.getenv("IA_PROVIDER", raw.get("provider", "auto")).strip().lower(),
             provider_chain=chain,
             providers=providers,
+            inference_deadline_seconds=float(
+                os.getenv(
+                    "BOT_INFERENCE_DEADLINE_SECONDS",
+                    raw.get("inference_deadline_seconds", 240.0),
+                )
+            ),
         )
 
 

--- a/bot/app/providers/error_mapping.py
+++ b/bot/app/providers/error_mapping.py
@@ -1,18 +1,50 @@
 """Translate LangChain/native SDK exceptions into the service's stable error categories.
 
-Every LangChain chat-model integration (langchain-openai, langchain-groq,
-langchain-google-genai, langchain-deepseek, langchain-ollama) wraps a
-provider SDK that follows the openai-python exception naming convention
-(``RateLimitError``, ``AuthenticationError``, ``APITimeoutError``, ...), so
-matching on the exception class name is a reliable, dependency-free way to
-recover a single stable category across all of them.
+Concrete transport/parser exception types are handled first. SDK exception
+names remain as a compatibility fallback because each LangChain integration
+wraps a different provider SDK.
 """
 
 import json
+from collections.abc import Iterator
 
+import httpx
+from langchain_core.exceptions import OutputParserException
 from pydantic import ValidationError
 
 from app.providers.base import AIProviderError
+
+_CONNECTION_ERROR_NAMES = {
+    "APIConnectionError",
+    "ConnectError",
+    "ConnectionError",
+    "ConnectionRefusedError",
+    "ConnectionResetError",
+    "NetworkError",
+    "ProxyError",
+}
+
+
+def _exception_chain(error: Exception) -> Iterator[BaseException]:
+    """Yield an exception and its explicit/implicit causes without looping."""
+
+    current: BaseException | None = error
+    seen: set[int] = set()
+
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _status_code(errors: tuple[BaseException, ...]) -> int | None:
+    for error in errors:
+        status = getattr(error, "status_code", None) or getattr(
+            getattr(error, "response", None), "status_code", None
+        )
+        if isinstance(status, int):
+            return status
+    return None
 
 
 def map_provider_error(provider_name: str, error: Exception) -> AIProviderError:
@@ -20,35 +52,41 @@ def map_provider_error(provider_name: str, error: Exception) -> AIProviderError:
         return error
 
     label = provider_name.capitalize()
-    status_code = getattr(error, "status_code", None) or getattr(
-        getattr(error, "response", None), "status_code", None
-    )
-    error_type = type(error).__name__
+    errors = tuple(_exception_chain(error))
+    status_code = _status_code(errors)
+    error_types = {type(item).__name__ for item in errors}
 
-    if isinstance(error, json.JSONDecodeError):
+    if any(isinstance(item, json.JSONDecodeError) for item in errors):
         return AIProviderError(f"{label} returned invalid JSON.", category="invalid_json")
-    if isinstance(error, ValidationError):
+    if any(isinstance(item, ValidationError) for item in errors):
         return AIProviderError(
             f"{label} returned data outside the expected schema.",
             category="schema_validation_error",
         )
-    if "Timeout" in error_type:
+    if any(isinstance(item, OutputParserException) for item in errors):
+        return AIProviderError(
+            f"{label} returned a response that could not be parsed.",
+            category="response_parsing_error",
+        )
+    if any(isinstance(item, (httpx.TimeoutException, TimeoutError)) for item in errors) or any(
+        "Timeout" in error_type for error_type in error_types
+    ):
         return AIProviderError(f"{label} timed out.", category="timeout")
-    if "RateLimit" in error_type or status_code == 429:
+    if any("RateLimit" in error_type for error_type in error_types) or status_code == 429:
         return AIProviderError(
             f"{label} rate-limited the request.", category="rate_limit_429", status_http=429
         )
-    if "Authentication" in error_type or status_code == 401:
+    if any("Authentication" in error_type for error_type in error_types) or status_code == 401:
         return AIProviderError(
             f"{label} rejected the authentication.", category="auth_error_401", status_http=401
         )
-    if "PermissionDenied" in error_type or status_code == 403:
+    if any("PermissionDenied" in error_type for error_type in error_types) or status_code == 403:
         return AIProviderError(
             f"{label} rejected the requested permission.",
             category="permission_error_403",
             status_http=403,
         )
-    if "NotFound" in error_type or status_code == 404:
+    if any("NotFound" in error_type for error_type in error_types) or status_code == 404:
         return AIProviderError(
             f"{label} did not recognize or did not make available the configured model.",
             category="invalid_model",
@@ -60,11 +98,20 @@ def map_provider_error(provider_name: str, error: Exception) -> AIProviderError:
             category="request_too_large",
             status_http=413,
         )
-    if "BadRequest" in error_type or "InvalidRequest" in error_type or status_code == 400:
+    if (
+        any(
+            "BadRequest" in error_type or "InvalidRequest" in error_type
+            for error_type in error_types
+        )
+        or status_code == 400
+    ):
         return AIProviderError(
             f"{label} rejected the request format.", category="invalid_request", status_http=400
         )
-    if "Connection" in error_type:
+    if any(
+        isinstance(item, (httpx.RequestError, httpx.InvalidURL, ConnectionError))
+        for item in errors
+    ) or bool(error_types & _CONNECTION_ERROR_NAMES):
         return AIProviderError(f"Could not connect to {label}.", category="network_error")
     if status_code is not None and status_code >= 500:
         return AIProviderError(

--- a/bot/app/providers/factory.py
+++ b/bot/app/providers/factory.py
@@ -40,4 +40,6 @@ class ProviderFactory(ProviderFactoryInterface):
             base_url=provider_settings.base_url,
             timeout=provider_settings.timeout_seconds,
             output_language=self._settings.ai.output_language,
+            reasoning=provider_settings.reasoning,
+            max_output_tokens=provider_settings.max_output_tokens,
         )

--- a/bot/app/providers/langchain_provider.py
+++ b/bot/app/providers/langchain_provider.py
@@ -32,6 +32,8 @@ class LangChainProvider(AIProvider):
         base_url: str | None = None,
         timeout: float = 120.0,
         output_language: str = "pt-BR",
+        reasoning: bool | None = None,
+        max_output_tokens: int | None = None,
     ) -> None:
         if name not in _MODEL_PROVIDERS:
             raise AIProviderError(f"Unsupported provider '{name}'.", category="invalid_model")
@@ -41,6 +43,8 @@ class LangChainProvider(AIProvider):
         self.name = name
         self.model = model
         self.output_language = output_language
+        self.reasoning = reasoning
+        self.max_output_tokens = max_output_tokens
         self._chat_model = init_chat_model(
             model,
             model_provider=_MODEL_PROVIDERS[name],
@@ -56,7 +60,21 @@ class LangChainProvider(AIProvider):
     async def run_structured(
         self, prompt: str, schema: type[BaseModel], temperature: float = 0.2
     ) -> BaseModel | None:
-        structured_model = self._chat_model.bind(temperature=temperature).with_structured_output(schema)
+        if self.name == "ollama":
+            ollama_options = {"temperature": temperature}
+            if self.max_output_tokens is not None:
+                ollama_options["num_predict"] = self.max_output_tokens
+            # Apply Ollama invocation options after structured output. ChatOllama's
+            # with_structured_output() creates its own binding for `format`; applying
+            # it second would replace reasoning/options instead of combining them.
+            structured_model = self._chat_model.with_structured_output(schema).bind(
+                reasoning=False if self.reasoning is None else self.reasoning,
+                options=ollama_options,
+            )
+        else:
+            structured_model = self._chat_model.bind(
+                temperature=temperature
+            ).with_structured_output(schema)
         try:
             result = await structured_model.ainvoke(prompt)
         except Exception as error:

--- a/bot/app/services/ai/resume_analysis_manager.py
+++ b/bot/app/services/ai/resume_analysis_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -13,6 +15,8 @@ from app.services.ai.interfaces import ResumeAnalysisManagerInterface
 from app.services.ai.resume_builder_prompt import build_resume_construction_prompt
 from app.services.ai.resume_score_prompt import build_resume_score_prompt
 
+logger = logging.getLogger(__name__)
+
 _ERROR_MESSAGES = {
     "missing_api_key": "{label} has no minimal configuration.",
     "auth_error_401": "{label} rejected the authentication.",
@@ -27,6 +31,7 @@ _ERROR_MESSAGES = {
     "json_truncated": "{label} returned apparently truncated JSON.",
     "empty_response": "{label} returned an empty response.",
     "schema_validation_error": "{label} returned data outside the expected schema.",
+    "response_parsing_error": "{label} returned a response that could not be parsed.",
     "provider_unavailable": "{label} is temporarily unavailable.",
     "unknown_provider_error": "{label} returned an unclassified error.",
 }
@@ -130,6 +135,30 @@ class ResumeAnalysisManager(ResumeAnalysisManagerInterface):
         factory: Callable[[str], AIProvider] | None,
     ) -> _SchemaT:
         factory = factory or self._provider_factory.create
+        try:
+            return await asyncio.wait_for(
+                self._run_provider_chain(prompt, schema, factory),
+                timeout=self._settings.ai.inference_deadline_seconds,
+            )
+        except TimeoutError as error:
+            logger.warning(
+                "AI inference deadline exceeded.",
+                exc_info=True,
+                extra={
+                    "error_category": "timeout",
+                    "inference_deadline_seconds": self._settings.ai.inference_deadline_seconds,
+                },
+            )
+            raise AIProviderError(
+                "AI inference exceeded the time limit.", category="timeout"
+            ) from error
+
+    async def _run_provider_chain(
+        self,
+        prompt: str,
+        schema: type[_SchemaT],
+        factory: Callable[[str], AIProvider],
+    ) -> _SchemaT:
         last_error: AIProviderError | None = None
 
         for name in self.get_provider_chain():
@@ -140,7 +169,21 @@ class ResumeAnalysisManager(ResumeAnalysisManagerInterface):
                 provider = factory(name)
                 result = await provider.run_structured(prompt, schema, temperature=0.2)
             except Exception as error:
-                last_error = self._safe_error(name, error)
+                safe_error = self._safe_error(name, error)
+                provider_settings = self._settings.ai.providers.get(name)
+                logger.warning(
+                    "AI provider attempt failed.",
+                    exc_info=True,
+                    extra={
+                        "provider_name": name,
+                        "error_category": safe_error.category,
+                        "provider_status": safe_error.status_http,
+                        "exception_type": type(error).__name__,
+                        "model_name": getattr(provider_settings, "model", None),
+                        "provider_base_url": getattr(provider_settings, "base_url", None),
+                    },
+                )
+                last_error = safe_error
                 continue
 
             if isinstance(result, schema):

--- a/bot/app/services/ai/resume_builder_prompt.py
+++ b/bot/app/services/ai/resume_builder_prompt.py
@@ -1,10 +1,9 @@
 """Builds the prompt used to ask the AI to construct the best possible ATS-optimized resume."""
 
-import json
 from datetime import date
 
 from app.models.github_profile import GitHubProfile
-from app.models.resume_analysis import BuiltResumeResult, SkillItem
+from app.models.resume_analysis import SkillItem
 from app.services.ai.prompt_sources import build_source_sections
 
 
@@ -17,7 +16,6 @@ def build_resume_construction_prompt(
     portfolio_url: str | None = None,
     additional_skills: list[SkillItem] | None = None,
 ) -> str:
-    schema = BuiltResumeResult.model_json_schema()
     instructions = (
         f"Today's date is {date.today().isoformat()}. "
         "You are an ATS and resume-writing expert. Read the resume text below — and "
@@ -38,7 +36,7 @@ def build_resume_construction_prompt(
         "sources, never fabricated. Also produce a 0-100 score for how well-written and "
         "ATS-friendly the constructed resume is. "
         f"Write the professional_summary in {output_language}. "
-        f"Return only valid JSON matching this schema: {json.dumps(schema, ensure_ascii=False)}"
+        "Return only the structured JSON response, without Markdown or commentary."
     )
 
     sources = build_source_sections(

--- a/bot/app/services/ai/resume_score_prompt.py
+++ b/bot/app/services/ai/resume_score_prompt.py
@@ -1,9 +1,7 @@
 """Builds the prompt used to ask the AI for an ATS quality score of a resume as-is."""
 
-import json
-
 from app.models.github_profile import GitHubProfile
-from app.models.resume_analysis import ResumeScoreResult, SkillItem
+from app.models.resume_analysis import SkillItem
 from app.services.ai.prompt_sources import build_source_sections
 
 
@@ -16,7 +14,6 @@ def build_resume_score_prompt(
     portfolio_url: str | None = None,
     additional_skills: list[SkillItem] | None = None,
 ) -> str:
-    schema = ResumeScoreResult.model_json_schema()
     instructions = (
         "You are an ATS (Applicant Tracking System) evaluation expert. Read the resume "
         "text below — and the supporting sources after it, if any — and judge how "
@@ -24,7 +21,7 @@ def build_resume_score_prompt(
         "restructure, or extract the resume — only evaluate it. Produce a 0-100 score "
         "and one direct, actionable improvement suggestion. "
         f"Write the suggestion in {output_language}. "
-        f"Return only valid JSON matching this schema: {json.dumps(schema, ensure_ascii=False)}"
+        "Return only the structured JSON response, without Markdown or commentary."
     )
 
     sources = build_source_sections(

--- a/bot/config.yaml.example
+++ b/bot/config.yaml.example
@@ -9,6 +9,9 @@ server:
 
 ai:
   enabled_by_default: true
+  # Total wall-clock budget for the complete provider chain. Unlike the
+  # transport timeout below, this also stops an active token generation.
+  inference_deadline_seconds: 240.0
   # Language the AI is instructed to write end-user-facing text in.
   output_language: "pt-BR"
   # "auto" walks provider_chain in order, skipping unconfigured providers.
@@ -29,6 +32,19 @@ ai:
       model: "gpt-5.5"
       timeout_seconds: 120.0
     ollama:
-      model: "qwen3:8b"
-      base_url: "http://localhost:11434"
+      # The 4B model is the local-development default. qwen3:8b remains
+      # available through OLLAMA_MODEL on machines with more CPU/RAM budget.
+      model: "qwen3:4b"
+      # Default for running the bot directly on the host. Docker Compose
+      # overrides this with http://ollama:11434 through OLLAMA_BASE_URL.
+      base_url: "http://127.0.0.1:11434"
+      # Resume extraction does not benefit enough from hidden chain-of-thought
+      # to justify its CPU latency. This maps to ChatOllama(reasoning=False).
+      reasoning: false
+      # A dense representative resume completed naturally at 1789 tokens, and
+      # a second valid sample at 1932. This leaves measured headroom without
+      # allowing unbounded generation or exhausting the 4096-token context.
+      num_predict: 2048
+      # HTTP transport inactivity timeout; the total inference deadline above
+      # is the wall-clock limit for an active generation.
       timeout_seconds: 120.0

--- a/bot/tests/test_langchain_provider.py
+++ b/bot/tests/test_langchain_provider.py
@@ -1,16 +1,25 @@
 import asyncio
 
+import httpx
 import pytest
+from langchain_core.exceptions import OutputParserException
+from ollama import ResponseError
 
 from app.models.resume_analysis import BuiltResumeResult
 from app.providers.base import AIProviderError
+from app.providers.error_mapping import map_provider_error
 from app.providers.langchain_provider import LangChainProvider
 
 
 class FakeStructuredRunnable:
-    def __init__(self, result=None, error: Exception | None = None):
+    def __init__(self, chat_model, result=None, error: Exception | None = None):
+        self._chat_model = chat_model
         self._result = result
         self._error = error
+
+    def bind(self, **kwargs):
+        self._chat_model.bound_kwargs = kwargs
+        return self
 
     async def ainvoke(self, prompt):
         if self._error is not None:
@@ -23,13 +32,15 @@ class FakeChatModel:
         self._result = result
         self._error = error
         self.bound_kwargs: dict | None = None
+        self.structured_schema = None
 
     def bind(self, **kwargs):
         self.bound_kwargs = kwargs
         return self
 
     def with_structured_output(self, schema):
-        return FakeStructuredRunnable(self._result, self._error)
+        self.structured_schema = schema
+        return FakeStructuredRunnable(self, self._result, self._error)
 
 
 def make_provider(result=None, error: Exception | None = None) -> LangChainProvider:
@@ -46,6 +57,28 @@ def test_run_structured_returns_the_parsed_model() -> None:
 
     assert response is expected
     assert provider._chat_model.bound_kwargs == {"temperature": 0.1}
+    assert provider._chat_model.structured_schema is BuiltResumeResult
+
+
+def test_ollama_disables_reasoning_and_limits_resume_output() -> None:
+    expected = BuiltResumeResult(score=80)
+    provider = LangChainProvider(
+        name="ollama",
+        model="qwen3:4b",
+        base_url="http://127.0.0.1:11434",
+        reasoning=False,
+        max_output_tokens=2048,
+    )
+    provider._chat_model = FakeChatModel(result=expected)
+
+    response = asyncio.run(provider.run_structured("resume prompt", BuiltResumeResult, 0.2))
+
+    assert response is expected
+    assert provider._chat_model.bound_kwargs == {
+        "reasoning": False,
+        "options": {"temperature": 0.2, "num_predict": 2048},
+    }
+    assert provider._chat_model.structured_schema is BuiltResumeResult
 
 
 def test_empty_structured_response_raises_empty_response_category() -> None:
@@ -91,4 +124,83 @@ def test_provider_requires_api_key_except_for_ollama() -> None:
         LangChainProvider(name="groq", model="some-model", api_key="")
     assert captured.value.category == "missing_api_key"
 
-    LangChainProvider(name="ollama", model="qwen3:8b", base_url="http://localhost:11434")
+    LangChainProvider(name="ollama", model="qwen3:4b", base_url="http://127.0.0.1:11434")
+
+
+@pytest.mark.parametrize(
+    "error,expected_category,expected_message",
+    [
+        (
+            httpx.ConnectError(
+                "All connection attempts failed",
+                request=httpx.Request("POST", "http://ollama:11434/api/chat"),
+            ),
+            "network_error",
+            "Could not connect to Ollama.",
+        ),
+        (
+            httpx.ReadTimeout(
+                "The provider exceeded its timeout",
+                request=httpx.Request("POST", "http://ollama:11434/api/chat"),
+            ),
+            "timeout",
+            "Ollama timed out.",
+        ),
+        (
+            httpx.RemoteProtocolError("The provider closed the connection unexpectedly"),
+            "network_error",
+            "Could not connect to Ollama.",
+        ),
+        (
+            httpx.InvalidURL("Invalid Ollama URL"),
+            "network_error",
+            "Could not connect to Ollama.",
+        ),
+        (
+            ResponseError("model 'missing-model' not found", status_code=404),
+            "invalid_model",
+            "Ollama did not recognize or did not make available the configured model.",
+        ),
+        (
+            OutputParserException(
+                "Failed to parse the model response",
+                llm_output="internal malformed model output",
+            ),
+            "response_parsing_error",
+            "Ollama returned a response that could not be parsed.",
+        ),
+    ],
+)
+def test_real_ollama_errors_are_mapped_without_leaking_details(
+    error: Exception, expected_category: str, expected_message: str
+) -> None:
+    mapped = map_provider_error("ollama", error)
+
+    assert mapped.category == expected_category
+    assert str(mapped) == expected_message
+    assert str(error) not in str(mapped)
+
+
+def test_run_structured_preserves_the_original_exception_as_cause() -> None:
+    original = httpx.ConnectError(
+        "internal connection detail",
+        request=httpx.Request("POST", "http://ollama:11434/api/chat"),
+    )
+    provider = make_provider(error=original)
+
+    with pytest.raises(AIProviderError) as captured:
+        asyncio.run(provider.run_structured("prompt", BuiltResumeResult))
+
+    assert captured.value.category == "network_error"
+    assert captured.value.__cause__ is original
+
+
+def test_nested_builtin_connection_error_is_recognized() -> None:
+    original = ConnectionRefusedError("connection refused by socket")
+    wrapper = RuntimeError("provider SDK wrapper")
+    wrapper.__cause__ = original
+
+    mapped = map_provider_error("ollama", wrapper)
+
+    assert mapped.category == "network_error"
+    assert str(mapped) == "Could not connect to Ollama."

--- a/bot/tests/test_providers.py
+++ b/bot/tests/test_providers.py
@@ -52,15 +52,50 @@ CONFIGURED_DEFAULT_MODELS = {
     "gemini": "gemini-3.5-flash",
     "deepseek": "deepseek-v4-flash",
     "openai": "gpt-5.5",
-    "ollama": "qwen3:8b",
+    "ollama": "qwen3:4b",
 }
 
 
 @pytest.mark.parametrize("name,expected_model", CONFIGURED_DEFAULT_MODELS.items())
-def test_config_yaml_default_models_match_expected(name, expected_model) -> None:
+def test_config_yaml_default_models_match_expected(name, expected_model, monkeypatch) -> None:
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
     settings = Settings.load()
 
     assert settings.ai.providers[name].model == expected_model
+
+
+def test_ollama_environment_overrides_yaml_configuration(monkeypatch) -> None:
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.internal:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "custom-model:latest")
+    monkeypatch.setenv("OLLAMA_REASONING", "true")
+    monkeypatch.setenv("OLLAMA_NUM_PREDICT", "3072")
+    monkeypatch.setenv("BOT_INFERENCE_DEADLINE_SECONDS", "75")
+
+    settings = Settings.load()
+
+    assert settings.ai.providers["ollama"].base_url == "http://ollama.internal:11434"
+    assert settings.ai.providers["ollama"].model == "custom-model:latest"
+    assert settings.ai.providers["ollama"].reasoning is True
+    assert settings.ai.providers["ollama"].max_output_tokens == 3072
+    assert settings.ai.inference_deadline_seconds == 75
+
+
+def test_ollama_local_defaults_disable_reasoning_and_bound_output(monkeypatch) -> None:
+    for variable in (
+        "OLLAMA_MODEL",
+        "OLLAMA_REASONING",
+        "OLLAMA_NUM_PREDICT",
+        "BOT_INFERENCE_DEADLINE_SECONDS",
+    ):
+        monkeypatch.delenv(variable, raising=False)
+
+    settings = Settings.load()
+    ollama = settings.ai.providers["ollama"]
+
+    assert ollama.model == "qwen3:4b"
+    assert ollama.reasoning is False
+    assert ollama.max_output_tokens == 2048
+    assert settings.ai.inference_deadline_seconds == 240
 
 
 def test_provider_unknown_returns_error() -> None:

--- a/bot/tests/test_resume_analysis_manager.py
+++ b/bot/tests/test_resume_analysis_manager.py
@@ -1,7 +1,9 @@
 import asyncio
+import time
 
 import pytest
 
+from app.core.settings import AISettings, ServerSettings, Settings
 from app.models.resume_analysis import BuiltResumeResult, ResumeHeader, ResumeScoreResult, SkillItem
 from app.providers.base import AIProviderError
 from app.providers.mock import MockProvider
@@ -157,6 +159,75 @@ def test_provider_failure_is_sanitized(monkeypatch, category, status) -> None:
     assert captured.value.category == category
     assert captured.value.status_http == status
     assert "detail interno" not in str(captured.value)
+
+
+def test_provider_failure_logs_original_exception_but_returns_sanitized_error(
+    monkeypatch, caplog
+) -> None:
+    monkeypatch.setenv("IA_PROVIDER", "groq")
+    monkeypatch.setenv("GROQ_API_KEY", "chave-ficticia-para-teste")
+
+    class FailingProvider(ProviderFake):
+        async def run_structured(self, prompt, schema, temperature=0.2):
+            raise AIProviderError(
+                "internal provider diagnostic 5c72",
+                category="network_error",
+            )
+
+    with caplog.at_level("WARNING", logger="app.services.ai.resume_analysis_manager"):
+        with pytest.raises(AIProviderError) as captured:
+            asyncio.run(
+                ResumeAnalysisManager().build_resume(
+                    RESUME_TEXT, lambda name: FailingProvider(name)
+                )
+            )
+
+    assert str(captured.value) == "Could not connect to Groq."
+    assert "internal provider diagnostic 5c72" not in str(captured.value)
+    assert "internal provider diagnostic 5c72" in caplog.text
+    assert caplog.records[-1].provider_name == "groq"
+    assert caplog.records[-1].error_category == "network_error"
+    assert caplog.records[-1].model_name == "openai/gpt-oss-120b"
+
+
+def test_total_inference_deadline_cancels_active_generation_and_is_sanitized(caplog) -> None:
+    settings = Settings(
+        server=ServerSettings(host="127.0.0.1", port=8000, log_level="INFO"),
+        ai=AISettings(
+            enabled_by_default=True,
+            output_language="pt-BR",
+            provider="mock",
+            provider_chain=("mock",),
+            inference_deadline_seconds=0.02,
+        ),
+    )
+    was_cancelled = False
+
+    class SlowProvider(MockProvider):
+        async def run_structured(self, prompt, schema, temperature=0.2):
+            nonlocal was_cancelled
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                was_cancelled = True
+                raise
+            return make_built()
+
+    started_at = time.monotonic()
+    with caplog.at_level("WARNING", logger="app.services.ai.resume_analysis_manager"):
+        with pytest.raises(AIProviderError) as captured:
+            asyncio.run(
+                ResumeAnalysisManager(settings=settings).build_resume(
+                    RESUME_TEXT, lambda _name: SlowProvider()
+                )
+            )
+
+    assert time.monotonic() - started_at < 0.5
+    assert was_cancelled is True
+    assert captured.value.category == "timeout"
+    assert str(captured.value) == "AI inference exceeded the time limit."
+    assert captured.value.__cause__ is not None
+    assert "AI inference deadline exceeded." in caplog.text
 
 
 def test_merges_github_and_portfolio_into_header_links_regardless_of_ai_output(monkeypatch) -> None:

--- a/bot/tests/test_resume_prompts.py
+++ b/bot/tests/test_resume_prompts.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from app.models.resume_analysis import BuiltResumeResult, ResumeScoreResult
+from app.services.ai.resume_builder_prompt import build_resume_construction_prompt
+from app.services.ai.resume_score_prompt import build_resume_score_prompt
+
+
+@pytest.mark.parametrize(
+    "prompt,schema,functional_instruction",
+    [
+        (
+            build_resume_construction_prompt("Resume source"),
+            BuiltResumeResult,
+            "never invent, infer, or fabricate a fact",
+        ),
+        (
+            build_resume_score_prompt("Resume source"),
+            ResumeScoreResult,
+            "Do not rewrite, restructure, or extract the resume",
+        ),
+    ],
+)
+def test_prompt_relies_on_structured_output_without_repeating_json_schema(
+    prompt, schema, functional_instruction
+) -> None:
+    serialized_schema = json.dumps(schema.model_json_schema(), ensure_ascii=False)
+
+    assert serialized_schema not in prompt
+    assert '"$defs"' not in prompt
+    assert '"properties"' not in prompt
+    assert functional_instruction in prompt
+    assert "Return only the structured JSON response" in prompt

--- a/bot/tests/test_timeout_hierarchy.py
+++ b/bot/tests/test_timeout_hierarchy.py
@@ -1,0 +1,35 @@
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _example_environment() -> dict[str, str]:
+    values = {}
+    for line in (REPOSITORY_ROOT / ".env.example").read_text().splitlines():
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+    return values
+
+
+def test_request_timeout_hierarchy_leaves_each_layer_time_to_respond() -> None:
+    environment = _example_environment()
+    bot_config = yaml.safe_load(
+        (REPOSITORY_ROOT / "bot/config.yaml.example").read_text()
+    )
+    nginx_config = (REPOSITORY_ROOT / "frontend/nginx.conf").read_text()
+    proxy_match = re.search(r"proxy_read_timeout\s+(\d+)s;", nginx_config)
+
+    assert proxy_match is not None
+    inference_deadline = float(bot_config["ai"]["inference_deadline_seconds"])
+    laravel_timeout = float(environment["BOT_TIMEOUT_SECONDS"])
+    proxy_timeout = float(proxy_match.group(1))
+
+    assert inference_deadline == float(environment["BOT_INFERENCE_DEADLINE_SECONDS"])
+    assert inference_deadline < laravel_timeout < proxy_timeout
+    assert laravel_timeout - inference_deadline >= 20
+    assert proxy_timeout - laravel_timeout >= 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,38 @@ services:
     networks:
       - bomcurriculo
 
+  ollama:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:0.33.3}
+    restart: unless-stopped
+    ports:
+      - "${OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - OLLAMA_HOST=http://127.0.0.1:11434 ollama list >/dev/null 2>&1
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - bomcurriculo
+
+  ollama-model:
+    image: ${OLLAMA_IMAGE:-ollama/ollama:0.33.3}
+    restart: "no"
+    environment:
+      OLLAMA_HOST: ${OLLAMA_BASE_URL:-http://ollama:11434}
+    command:
+      - pull
+      - "${OLLAMA_MODEL:-qwen3:4b}"
+    depends_on:
+      ollama:
+        condition: service_healthy
+    networks:
+      - bomcurriculo
+
   backend:
     build:
       context: ./backend
@@ -30,7 +62,10 @@ services:
     env_file:
       - ./backend/.env
     environment:
-      BOT_URL: http://bot:8000
+      BOT_URL: ${BOT_URL:-http://bot:8000}
+      BOT_CONNECT_TIMEOUT_SECONDS: ${BOT_CONNECT_TIMEOUT_SECONDS:-5}
+      BOT_HEALTH_TIMEOUT_SECONDS: ${BOT_HEALTH_TIMEOUT_SECONDS:-5}
+      BOT_TIMEOUT_SECONDS: ${BOT_TIMEOUT_SECONDS:-260}
     ports:
       - "${BACKEND_PORT:-9000}:9000"
     volumes:
@@ -60,6 +95,12 @@ services:
     restart: unless-stopped
     env_file:
       - ./bot/.env
+    environment:
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-qwen3:4b}
+      OLLAMA_REASONING: ${OLLAMA_REASONING:-false}
+      OLLAMA_NUM_PREDICT: ${OLLAMA_NUM_PREDICT:-2048}
+      BOT_INFERENCE_DEADLINE_SECONDS: ${BOT_INFERENCE_DEADLINE_SECONDS:-240}
     ports:
       - "${BOT_PORT:-8000}:8000"
     healthcheck:
@@ -72,6 +113,9 @@ services:
       timeout: 5s
       retries: 12
       start_period: 20s
+    depends_on:
+      ollama-model:
+        condition: service_completed_successfully
     networks:
       - bomcurriculo
 
@@ -111,3 +155,4 @@ networks:
 volumes:
   postgres_data:
   backend_storage:
+  ollama_data:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -27,7 +27,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_connect_timeout 10s;
-        proxy_read_timeout 120s;
+        proxy_read_timeout 280s;
     }
 
     location /assets/ {


### PR DESCRIPTION
## Description

Fixes timeout and performance issues in the synchronous Laravel → bot → Ollama resume-processing flow.

Previously, Nginx could close the request before Laravel or the bot returned a structured response. Local inference was also using a heavier model configuration with reasoning enabled and no generation limit.

This change:

* disables Ollama reasoning for resume generation and analysis;
* removes the redundant JSON Schema text while preserving LangChain structured output;
* limits generation to 2048 tokens;
* adds a 240-second inference deadline;
* aligns the timeout hierarchy to 240s bot < 260s Laravel < 280s Nginx;
* changes the local default model to `qwen3:4b`, while keeping `OLLAMA_MODEL` configurable;
* adds Ollama to Docker Compose with automatic model download and persistent storage;
* preserves internal exception logging while sanitizing public error responses;
* updates configuration examples, documentation, and tests.

The complete Docker Compose flow through Nginx → Laravel → bot → Ollama was tested successfully and returned HTTP 200 without timing out.

Asynchronous resume processing can be considered separately in the future if inference latency remains too high.

The pre-existing frontend `/healthz` healthcheck issue is outside the scope of this PR.

## AI Usage

* [x] Vibe coding
* [x] Research

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Documentation
* [x] Chore / Infrastructure

## Affected area

* [ ] Frontend
* [x] Backend
* [ ] Mobile
* [x] Bot
* [ ] CI/CD

## Checklist

* [x] Tested locally
* [x] Added/updated tests when necessary
* [x] Updated the documentation when necessary

## How to test

1. Prepare the environment files according to the project README.

2. Validate the Docker Compose configuration:

   ```bash
   docker compose config --quiet
   ```

3. Build and start the stack:

   ```bash
   docker compose up -d --build
   ```

4. Confirm that Ollama downloaded the default model:

   ```bash
   docker compose exec ollama ollama list
   ```

   The list should contain `qwen3:4b`.

5. Confirm that the services are available:

   ```bash
   curl http://localhost:8000/health
   curl http://localhost:9000/up
   ```

6. Test the bot directly with a valid PDF or DOCX resume:

   ```bash
   curl \
     --form "resume_cv=@/absolute/path/to/resume.pdf" \
     http://localhost:8000/api/v1/build
   ```

   The endpoint should return structured JSON without Markdown or reasoning content.

7. Test the complete flow at `http://localhost:5173` by registering or logging in, uploading a resume, and starting its processing.

   The request should complete successfully without Nginx returning `504 Gateway Timeout`.

8. Run the bot tests:

   ```bash
   cd bot
   uv sync --dev
   uv run pytest
   ```

9. Run the Laravel tests and formatting check:

   ```bash
   cd backend
   php artisan test
   vendor/bin/pint --test
   ```

10. Run the frontend tests, lint, and build:

    ```bash
    cd frontend
    npm test -- --run
    npm run lint
    npm run build
    ```

11. Verify whitespace and patch integrity:

    ```bash
    git diff --check
    ```
